### PR TITLE
One bug on VERTICAL MERGE + plus one personal change on SET_DRDN_HNDL

### DIFF
--- a/CODE/zcl_falv.clas.abap
+++ b/CODE/zcl_falv.clas.abap
@@ -1,35 +1,38 @@
-class zcl_falv definition
+class ZCL_FALV definition
   public
-  inheriting from cl_gui_alv_grid
+  inheriting from CL_GUI_ALV_GRID
   create public
 
-  global friends zcl_falv_layout .
+  global friends ZCL_FALV_LAYOUT .
 
-  public section.
+public section.
 
-    interfaces if_alv_rm_grid_friend .
+  interfaces IF_ALV_RM_GRID_FRIEND .
 
-    types:
-      begin of t_subcl_call,
+  types:
+    begin of t_subcl_call,
         progname type progname,
         line     type i,
         column   type i,
         class    type string,
       end of t_subcl_call .
-    types:
-      tt_subcl_call type sorted table of t_subcl_call with unique key progname line column .
-    types:
-      begin of t_email,
+  types:
+    tt_subcl_call type sorted table of t_subcl_call with unique key progname line column .
+  types:
+    begin of t_email,
         smtp_addr  type ad_smtpadr,
         express    type os_boolean,
         copy       type os_boolean,
         blind_copy type os_boolean,
       end of t_email .
-    types:
-      tt_email type table of t_email .
-    types t_column type ref to zcl_falv_column .
-    types t_columns type sorted table of t_column with unique key table_line .
-    constants: begin of color,
+  types:
+    tt_email type table of t_email .
+  types T_COLUMN type ref to ZCL_FALV_COLUMN .
+  types:
+    t_columns type sorted table of t_column with unique key table_line .
+
+  constants:
+    begin of color,
                  blue                         type char4 value 'C100',
                  blue_intensified             type char4 value 'C110',
                  blue_intensified_inversed    type char4 value 'C111',
@@ -58,37 +61,38 @@ class zcl_falv definition
                  orange_intensified           type char4 value 'C710',
                  orange_intensified_inversed  type char4 value 'C711',
                  orange_inversed              type char4 value 'C701',
-               end of color ##NEEDED.
-    constants version type string value '740.1.0.19' ##NO_TEXT.
-    constants cc_name type char30 value 'CC_GRID' ##NO_TEXT.
-    constants c_screen_popup type sy-dynnr value '0200' ##NO_TEXT.
-    constants c_screen_full type sy-dynnr value '0100' ##NO_TEXT.
-    constants c_fscr_repid type sy-repid value 'SAPLZFALV' ##NO_TEXT.
-    data result type i read-only .
-    data splitter_row_1_height type i read-only .
-    data splitter_row_2_height type i read-only .
-    data splitter_row_3_height type i read-only .
-    constants fc_back type sy-ucomm value 'BACK' ##NO_TEXT.
-    constants fc_up type sy-ucomm value 'UP' ##NO_TEXT.
-    constants fc_exit type sy-ucomm value 'EXIT' ##NO_TEXT.
-    constants fc_cancel type sy-ucomm value 'CANCEL' ##NO_TEXT.
-    constants fc_mass_replace type sy-ucomm value 'MASS_REPL' ##NO_TEXT.
-    constants fc_save type sy-ucomm value '&DATA_SAVE' ##NO_TEXT.
-    constants fc_print type sy-ucomm value 'PRINT' ##NO_TEXT.
-    constants fc_find type sy-ucomm value 'FIND' ##NO_TEXT.
-    constants fc_find_next type sy-ucomm value 'FINDNEXT' ##NO_TEXT.
-    constants fc_first_page type sy-ucomm value 'PGHOME' ##NO_TEXT.
-    constants fc_last_page type sy-ucomm value 'PGEND' ##NO_TEXT.
-    constants fc_previous_page type sy-ucomm value 'PGUP' ##NO_TEXT.
-    constants fc_next_page type sy-ucomm value 'PGDOWN' ##NO_TEXT.
-    constants button_normal type tb_btype value '0' ##NO_TEXT.
-    constants button_menu_default type tb_btype value '1' ##NO_TEXT.
-    constants button_menu type tb_btype value '2' ##NO_TEXT.
-    constants button_separator type tb_btype value '3' ##NO_TEXT.
-    constants button_radiobutton type tb_btype value '4' ##NO_TEXT.
-    constants button_checkbox type tb_btype value '5' ##NO_TEXT.
-    constants button_menu_entry type tb_btype value '6' ##NO_TEXT.
-    constants: begin of symbol,
+               end of color .
+  constants VERSION type STRING value '740.1.0.19' ##NO_TEXT.
+  constants CC_NAME type CHAR30 value 'CC_GRID' ##NO_TEXT.
+  constants C_SCREEN_POPUP type SY-DYNNR value '0200' ##NO_TEXT.
+  constants C_SCREEN_FULL type SY-DYNNR value '0100' ##NO_TEXT.
+  constants C_FSCR_REPID type SY-REPID value 'SAPLZFALV' ##NO_TEXT.
+  data RESULT type I read-only .
+  data SPLITTER_ROW_1_HEIGHT type I read-only .
+  data SPLITTER_ROW_2_HEIGHT type I read-only .
+  data SPLITTER_ROW_3_HEIGHT type I read-only .
+  constants FC_BACK type SY-UCOMM value 'BACK' ##NO_TEXT.
+  constants FC_UP type SY-UCOMM value 'UP' ##NO_TEXT.
+  constants FC_EXIT type SY-UCOMM value 'EXIT' ##NO_TEXT.
+  constants FC_CANCEL type SY-UCOMM value 'CANCEL' ##NO_TEXT.
+  constants FC_MASS_REPLACE type SY-UCOMM value 'MASS_REPL' ##NO_TEXT.
+  constants FC_SAVE type SY-UCOMM value '&DATA_SAVE' ##NO_TEXT.
+  constants FC_PRINT type SY-UCOMM value 'PRINT' ##NO_TEXT.
+  constants FC_FIND type SY-UCOMM value 'FIND' ##NO_TEXT.
+  constants FC_FIND_NEXT type SY-UCOMM value 'FINDNEXT' ##NO_TEXT.
+  constants FC_FIRST_PAGE type SY-UCOMM value 'PGHOME' ##NO_TEXT.
+  constants FC_LAST_PAGE type SY-UCOMM value 'PGEND' ##NO_TEXT.
+  constants FC_PREVIOUS_PAGE type SY-UCOMM value 'PGUP' ##NO_TEXT.
+  constants FC_NEXT_PAGE type SY-UCOMM value 'PGDOWN' ##NO_TEXT.
+  constants BUTTON_NORMAL type TB_BTYPE value '0' ##NO_TEXT.
+  constants BUTTON_MENU_DEFAULT type TB_BTYPE value '1' ##NO_TEXT.
+  constants BUTTON_MENU type TB_BTYPE value '2' ##NO_TEXT.
+  constants BUTTON_SEPARATOR type TB_BTYPE value '3' ##NO_TEXT.
+  constants BUTTON_RADIOBUTTON type TB_BTYPE value '4' ##NO_TEXT.
+  constants BUTTON_CHECKBOX type TB_BTYPE value '5' ##NO_TEXT.
+  constants BUTTON_MENU_ENTRY type TB_BTYPE value '6' ##NO_TEXT.
+  constants:
+    begin of symbol,
                  empty_space        type char01 value ' ',
                  plus_box           type char01 value '!',
                  minus_box          type char01 value '"',
@@ -144,589 +148,609 @@ class zcl_falv definition
                  flash              type char01 value  'V',
                  large_square       type char01 value  'W',
                  ellipsis           type char01 value  'X',
-               end of symbol.
-    data main_container type ref to cl_gui_container read-only .
-    data split_container type ref to cl_gui_splitter_container .
-    data main_split_container type ref to cl_gui_splitter_container .
-    data top_of_page_container type ref to cl_gui_container .
-    data variant type disvariant .
-    data layout_save type char01 .
-    data exclude_functions type ui_functions .
-    data fcat type lvc_t_fcat .
-    data sort type lvc_t_sort .
-    data filter type lvc_t_filt .
-    data lvc_layout type lvc_s_layo read-only .
-    data layout type ref to zcl_falv_layout .
-    data gui_status type ref to zcl_falv_dynamic_status .
-    data screen type sy-dynnr read-only .
-    data outtab type ref to data .
-    data title_v1 type string .
-    data title_v2 type string .
-    data title_v3 type string .
-    data title_v4 type string .
-    data title_v5 type string .
-    data delay_move_current_cell type i read-only value 20 ##NO_TEXT.
-    data delay_change_selection type i read-only value 20 ##NO_TEXT.
-    data top_of_page_height type i value 150 ##NO_TEXT.
-    data error_log_height type i value 100 ##NO_TEXT.
-    data grid type ref to cl_gui_alv_grid .
-    data built_in_screen type abap_bool  read-only.
-    data: buffering_active type abap_bool value abap_true,
-          bypassing_buffer type abap_bool value abap_false.
+               end of symbol .
+  data MAIN_CONTAINER type ref to CL_GUI_CONTAINER read-only .
+  data SPLIT_CONTAINER type ref to CL_GUI_SPLITTER_CONTAINER .
+  data MAIN_SPLIT_CONTAINER type ref to CL_GUI_SPLITTER_CONTAINER .
+  data TOP_OF_PAGE_CONTAINER type ref to CL_GUI_CONTAINER .
+  data VARIANT type DISVARIANT .
+  data LAYOUT_SAVE type CHAR01 .
+  data EXCLUDE_FUNCTIONS type UI_FUNCTIONS .
+  data FCAT type LVC_T_FCAT .
+  data SORT type LVC_T_SORT .
+  data FILTER type LVC_T_FILT .
+  data LVC_LAYOUT type LVC_S_LAYO read-only .
+  data LAYOUT type ref to ZCL_FALV_LAYOUT .
+  data GUI_STATUS type ref to ZCL_FALV_DYNAMIC_STATUS .
+  data SCREEN type SY-DYNNR read-only .
+  data OUTTAB type ref to DATA .
+  data TITLE_V1 type STRING .
+  data TITLE_V2 type STRING .
+  data TITLE_V3 type STRING .
+  data TITLE_V4 type STRING .
+  data TITLE_V5 type STRING .
+  data DELAY_MOVE_CURRENT_CELL type I read-only value 20 ##NO_TEXT.
+  data DELAY_CHANGE_SELECTION type I read-only value 20 ##NO_TEXT.
+  data TOP_OF_PAGE_HEIGHT type I value 150 ##NO_TEXT.
+  data ERROR_LOG_HEIGHT type I value 100 ##NO_TEXT.
+  data GRID type ref to CL_GUI_ALV_GRID .
+  data BUILT_IN_SCREEN type ABAP_BOOL read-only .
+  data BUFFERING_ACTIVE type ABAP_BOOL value ABAP_TRUE ##NO_TEXT.
+  data BYPASSING_BUFFER type ABAP_BOOL value ABAP_FALSE ##NO_TEXT.
 
-    class-methods create
-      importing
-        value(i_parent)          type ref to cl_gui_container optional
-        value(i_applogparent)    type ref to cl_gui_container optional
-        value(i_popup)           type abap_bool default abap_false
-        value(i_applog_embedded) type abap_bool default abap_false
-        value(i_subclass)        type ref to cl_abap_typedescr optional
-        value(i_handle)          type slis_handl optional
-      changing
-        !ct_table                type standard table
-      returning
-        value(rv_falv)           type ref to zcl_falv .
-    methods create_by_copy
-      importing
-        value(i_parent)       type ref to cl_gui_container optional
-        value(i_applogparent) type ref to cl_gui_container optional
-        value(i_popup)        type abap_bool default abap_false
-      returning
-        value(rv_falv)        type ref to zcl_falv .
-    class-methods create_by_type
-      importing
-        value(i_parent)          type ref to cl_gui_container optional
-        value(i_applogparent)    type ref to cl_gui_container optional
-        value(i_popup)           type abap_bool default abap_false
-        value(i_applog_embedded) type abap_bool default abap_false
-        value(i_subclass)        type ref to cl_abap_typedescr optional
-        !i_type                  type ref to cl_abap_typedescr
-      returning
-        value(rv_falv)           type ref to zcl_falv .
-    class-methods lvc_fcat_from_itab
-      importing
-        !it_table      type standard table
-      returning
-        value(rt_fcat) type lvc_t_fcat .
-    methods constructor
-      importing
-        value(i_shellstyle)  type i default 0
-        value(i_lifetime)    type i optional
-        value(i_parent)      type ref to cl_gui_container optional
-        value(i_appl_events) type char01 default space
-        !i_parentdbg         type ref to cl_gui_container optional
-        !i_applogparent      type ref to cl_gui_container optional
-        !i_graphicsparent    type ref to cl_gui_container optional
-        value(i_name)        type string optional
-        !i_fcat_complete     type sap_bool default space
-      exceptions
-        error_cntl_create
-        error_cntl_init
-        error_cntl_link
-        error_dp_create
-        object_created_manually.
-    methods pbo
-      importing
-        value(iv_dynnr) type sy-dynnr default sy-dynnr .
-    methods pai
-      importing
-        value(iv_dynnr) type sy-dynnr default sy-dynnr
-      changing
-        !c_ucomm        type sy-ucomm default sy-ucomm .
-    methods display final
-      importing
-                value(iv_force_grid)   type abap_bool default space
-                value(iv_start_row)    type i optional
-                value(iv_start_column) type i optional
-                value(iv_end_row)      type i optional
-                value(iv_end_column)   type i optional
-      returning value(r_falv)          type ref to zcl_falv.
-    methods exclude_function
-      importing
-                value(iv_ucomm) type sy-ucomm
-      returning value(r_falv)   type ref to zcl_falv .
-    methods column
-      importing
-        value(iv_fieldname) type lvc_s_fcat-fieldname
-      returning
-        value(rv_column)    type ref to zcl_falv_column .
-    methods soft_refresh
-      returning value(r_falv) type ref to zcl_falv .
-    methods set_mark_field
-      importing
-                value(iv_fieldname) type lvc_s_fcat-fieldname
-      returning value(r_falv)       type ref to zcl_falv .
-    methods set_editable
-      importing
-                value(iv_modify) type abap_bool default abap_false
-      returning value(r_falv)    type ref to zcl_falv .
-    methods set_readonly
-      returning value(r_falv) type ref to zcl_falv .
-    methods add_button
-      importing
-                value(iv_function)  type ui_func
-                value(iv_icon)      type icon_d optional
-                value(iv_quickinfo) type iconquick optional
-                value(iv_butn_type) type tb_btype optional
-                value(iv_disabled)  type abap_bool optional
-                value(iv_text)      type text40 optional
-                value(iv_checked)   type abap_bool optional
-      returning value(r_falv)       type ref to zcl_falv .
+  class-methods CREATE
+    importing
+      value(I_PARENT) type ref to CL_GUI_CONTAINER optional
+      value(I_APPLOGPARENT) type ref to CL_GUI_CONTAINER optional
+      value(I_POPUP) type ABAP_BOOL default ABAP_FALSE
+      value(I_APPLOG_EMBEDDED) type ABAP_BOOL default ABAP_FALSE
+      value(I_SUBCLASS) type ref to CL_ABAP_TYPEDESCR optional
+      value(I_HANDLE) type SLIS_HANDL optional
+    changing
+      !CT_TABLE type STANDARD TABLE
+    returning
+      value(RV_FALV) type ref to ZCL_FALV .
+  class-methods CREATE_BY_TYPE
+    importing
+      value(I_PARENT) type ref to CL_GUI_CONTAINER optional
+      value(I_APPLOGPARENT) type ref to CL_GUI_CONTAINER optional
+      value(I_POPUP) type ABAP_BOOL default ABAP_FALSE
+      value(I_APPLOG_EMBEDDED) type ABAP_BOOL default ABAP_FALSE
+      value(I_SUBCLASS) type ref to CL_ABAP_TYPEDESCR optional
+      !I_TYPE type ref to CL_ABAP_TYPEDESCR
+    returning
+      value(RV_FALV) type ref to ZCL_FALV .
+  class-methods LVC_FCAT_FROM_ITAB
+    importing
+      !IT_TABLE type STANDARD TABLE
+    returning
+      value(RT_FCAT) type LVC_T_FCAT .
+  methods ADD_BUTTON
+    importing
+      value(IV_FUNCTION) type UI_FUNC
+      value(IV_ICON) type ICON_D optional
+      value(IV_QUICKINFO) type ICONQUICK optional
+      value(IV_BUTN_TYPE) type TB_BTYPE optional
+      value(IV_DISABLED) type ABAP_BOOL optional
+      value(IV_TEXT) type TEXT40 optional
+      value(IV_CHECKED) type ABAP_BOOL optional
+    returning
+      value(R_FALV) type ref to ZCL_FALV .
+  methods COLUMN
+    importing
+      value(IV_FIELDNAME) type LVC_S_FCAT-FIELDNAME
+    returning
+      value(RV_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods CONSTRUCTOR
+    importing
+      value(I_SHELLSTYLE) type I default 0
+      value(I_LIFETIME) type I optional
+      value(I_PARENT) type ref to CL_GUI_CONTAINER optional
+      value(I_APPL_EVENTS) type CHAR01 default SPACE
+      !I_PARENTDBG type ref to CL_GUI_CONTAINER optional
+      !I_APPLOGPARENT type ref to CL_GUI_CONTAINER optional
+      !I_GRAPHICSPARENT type ref to CL_GUI_CONTAINER optional
+      value(I_NAME) type STRING optional
+      !I_FCAT_COMPLETE type SAP_BOOL default SPACE
+    exceptions
+      ERROR_CNTL_CREATE
+      ERROR_CNTL_INIT
+      ERROR_CNTL_LINK
+      ERROR_DP_CREATE
+      OBJECT_CREATED_MANUALLY .
+  methods CREATE_BY_COPY
+    importing
+      value(I_PARENT) type ref to CL_GUI_CONTAINER optional
+      value(I_APPLOGPARENT) type ref to CL_GUI_CONTAINER optional
+      value(I_POPUP) type ABAP_BOOL default ABAP_FALSE
+    returning
+      value(RV_FALV) type ref to ZCL_FALV .
     "! Don't call it from Toolbar event handler
     "! as it will cause endless loop
-    methods disable_button
-      importing
-                value(iv_function) type ui_func
-      returning value(r_falv)      type ref to zcl_falv .
+  methods DELETE_ALL_BUTTONS
+    importing
+      value(IV_EXCEPTIONS) type TTB_BUTTON optional
+    returning
+      value(R_FALV) type ref to ZCL_FALV .
     "! Don't call it from Toolbar event handler
     "! as it will cause endless loop
-    methods enable_button
-      importing
-                value(iv_function) type ui_func
-      returning value(r_falv)      type ref to zcl_falv .
+  methods DELETE_BUTTON
+    importing
+      value(IV_FUNCTION) type UI_FUNC
+    returning
+      value(R_FALV) type ref to ZCL_FALV .
     "! Don't call it from Toolbar event handler
     "! as it will cause endless loop
-    methods delete_button
-      importing
-                value(iv_function) type ui_func
-      returning value(r_falv)      type ref to zcl_falv .
+  methods DISABLE_BUTTON
+    importing
+      value(IV_FUNCTION) type UI_FUNC
+    returning
+      value(R_FALV) type ref to ZCL_FALV .
+  methods DISPLAY
+  final
+    importing
+      value(IV_FORCE_GRID) type ABAP_BOOL default SPACE
+      value(IV_START_ROW) type I optional
+      value(IV_START_COLUMN) type I optional
+      value(IV_END_ROW) type I optional
+      value(IV_END_COLUMN) type I optional
+    returning
+      value(R_FALV) type ref to ZCL_FALV .
     "! Don't call it from Toolbar event handler
     "! as it will cause endless loop
-    methods delete_all_buttons
-      importing
-                value(iv_exceptions) type ttb_button optional
-      returning value(r_falv)        type ref to zcl_falv .
-    methods set_cell_disabled
-      importing
-                value(iv_fieldname) type fieldname
-                value(iv_row)       type lvc_s_roid-row_id
-      returning value(r_falv)       type ref to zcl_falv .
-    methods set_cell_enabled
-      importing
-                value(iv_fieldname) type fieldname
-                value(iv_row)       type lvc_s_roid-row_id
-      returning value(r_falv)       type ref to zcl_falv .
-    methods set_cell_button
-      importing
-                value(iv_fieldname) type fieldname
-                value(iv_row)       type lvc_s_roid-row_id
-      returning value(r_falv)       type ref to zcl_falv .
-    methods set_cell_hotspot
-      importing
-                value(iv_fieldname) type fieldname
-                value(iv_row)       type lvc_s_roid-row_id
-      returning value(r_falv)       type ref to zcl_falv .
-    methods set_row_color
-      importing
-                value(iv_color) type char04
-                value(iv_row)   type lvc_s_roid-row_id
-      returning value(r_falv)   type ref to zcl_falv .
-    methods set_cell_color
-      importing
-                value(iv_fieldname) type fieldname
-                value(iv_color)     type lvc_s_colo
-                value(iv_row)       type lvc_s_roid-row_id
-      returning value(r_falv)       type ref to zcl_falv .
-    methods mass_replace .
-    methods export_to_excel
-      returning
-        value(rv_xstring) type xstring .
-    methods save_excel_localy
-      importing
-        value(iv_path)  type string optional
-      returning
-        value(rv_saved) type abap_bool .
-    methods hide_top_of_page
-      returning value(r_falv) type ref to zcl_falv .
-    methods show_top_of_page
-      returning value(r_falv) type ref to zcl_falv .
-    methods set_list_view
-      returning
-        value(r_falv) type ref to zcl_falv .
-    methods encode_picture_base64
-      importing
-        value(iv_xstring)   type xstring
-        value(iv_mime_type) type csequence
-      returning
-        value(rv_image)     type string .
-    methods get_file_from_mime
-      importing
-        value(iv_path)      type string
-      exporting
-        value(ev_xstring)   type xstring
-        value(ev_mime_type) type string .
-    methods get_picture_from_se78
-      importing
-        value(iv_name)    type stxbitmaps-tdname
-        value(iv_type)    type stxbitmaps-tdbtype default 'BCOL'
-        value(iv_id)      type stxbitmaps-tdid default 'BMAP'
-      returning
-        value(rv_xstring) type xstring .
-    methods send
-      importing
-                 value(iv_subject)     type csequence optional
-                 value(iv_sender)      type ad_smtpadr optional
-                 value(iv_sender_name) type ad_smtpadr optional
-                 value(iv_filename)    type csequence optional
-                 value(it_recipients)  type tt_email
-                 value(iv_body)        type string optional
-                 value(iv_importance)  type bcs_docimp optional
-                 value(iv_sensitivity) type so_obj_sns optional
-                 value(iv_immediately) type abap_bool optional
-                 value(iv_commit)      type abap_bool default abap_true
-      returning  value(r_falv)         type ref to zcl_falv
-      exceptions
-                 create_request_error
-                 create_document_error
-                 add_attachment_error
-                 add_document_error
-                 add_recipient_error
-                 add_sender_error
-                 send_error
-                 send_immediately_error .
-    methods hide_applog .
-    methods show_applog
-      returning
-        value(r_falv) type ref to zcl_falv .
+  methods ENABLE_BUTTON
+    importing
+      value(IV_FUNCTION) type UI_FUNC
+    returning
+      value(R_FALV) type ref to ZCL_FALV .
+  methods ENCODE_PICTURE_BASE64
+    importing
+      value(IV_XSTRING) type XSTRING
+      value(IV_MIME_TYPE) type CSEQUENCE
+    returning
+      value(RV_IMAGE) type STRING .
+  methods EXCLUDE_FUNCTION
+    importing
+      value(IV_UCOMM) type SY-UCOMM
+    returning
+      value(R_FALV) type ref to ZCL_FALV .
+  methods EXPORT_TO_EXCEL
+    returning
+      value(RV_XSTRING) type XSTRING .
     "! Cell can be editable by layout, by field-catalog or by cell styles
-    methods get_cell_enabled
-      importing
-        value(i_row)     type i
-        value(i_field)   type lvc_fname
-      returning
-        value(r_enabled) type abap_bool.
-    methods refresh_toolbar
-      returning value(r_falv) type ref to zcl_falv .
-    methods set_dummy_function_code
-      returning value(r_falv) type ref to zcl_falv .
-
-    methods set_frontend_fieldcatalog
-        redefinition .
-    methods set_frontend_layout
-        redefinition .
-    methods get_columns
-      returning value(rt_columns) type t_columns .
-    methods set_output_table
-      changing
-        !ct_table type standard table .
-    methods set_merge_horizontally
-      importing
-        !row           type i
-        !tab_col_merge type lvc_t_co01 .
-    methods set_merge_vertically
-      importing
-        !row           type i
-        !tab_col_merge type lvc_t_co01 .
+  methods GET_CELL_ENABLED
+    importing
+      value(I_ROW) type I
+      value(I_FIELD) type LVC_FNAME
+    returning
+      value(R_ENABLED) type ABAP_BOOL .
+  methods GET_COLUMNS
+    returning
+      value(RT_COLUMNS) type T_COLUMNS .
+  methods GET_FILE_FROM_MIME
+    importing
+      value(IV_PATH) type STRING
+    exporting
+      value(EV_XSTRING) type XSTRING
+      value(EV_MIME_TYPE) type STRING .
+  methods GET_PICTURE_FROM_SE78
+    importing
+      value(IV_NAME) type STXBITMAPS-TDNAME
+      value(IV_TYPE) type STXBITMAPS-TDBTYPE default 'BCOL'
+      value(IV_ID) type STXBITMAPS-TDID default 'BMAP'
+    returning
+      value(RV_XSTRING) type XSTRING .
+  methods HIDE_APPLOG .
+  methods HIDE_TOP_OF_PAGE
+    returning
+      value(R_FALV) type ref to ZCL_FALV .
+  methods INIT_CELL_STYLES .
+  methods MASS_REPLACE .
+  methods PAI
+    importing
+      value(IV_DYNNR) type SY-DYNNR default SY-DYNNR
+    changing
+      !C_UCOMM type SY-UCOMM default SY-UCOMM .
+  methods PBO
+    importing
+      value(IV_DYNNR) type SY-DYNNR default SY-DYNNR .
+  methods REDRAW_AFTER_MERGING_CHANGE .
+  methods REFRESH_TOOLBAR
+    returning
+      value(R_FALV) type ref to ZCL_FALV .
+  methods SAVE_EXCEL_LOCALY
+    importing
+      value(IV_PATH) type STRING optional
+    returning
+      value(RV_SAVED) type ABAP_BOOL .
+  methods SEND
+    importing
+      value(IV_SUBJECT) type CSEQUENCE optional
+      value(IV_SENDER) type AD_SMTPADR optional
+      value(IV_SENDER_NAME) type AD_SMTPADR optional
+      value(IV_FILENAME) type CSEQUENCE optional
+      value(IT_RECIPIENTS) type TT_EMAIL
+      value(IV_BODY) type STRING optional
+      value(IV_IMPORTANCE) type BCS_DOCIMP optional
+      value(IV_SENSITIVITY) type SO_OBJ_SNS optional
+      value(IV_IMMEDIATELY) type ABAP_BOOL optional
+      value(IV_COMMIT) type ABAP_BOOL default ABAP_TRUE
+    returning
+      value(R_FALV) type ref to ZCL_FALV
+    exceptions
+      CREATE_REQUEST_ERROR
+      CREATE_DOCUMENT_ERROR
+      ADD_ATTACHMENT_ERROR
+      ADD_DOCUMENT_ERROR
+      ADD_RECIPIENT_ERROR
+      ADD_SENDER_ERROR
+      SEND_ERROR
+      SEND_IMMEDIATELY_ERROR .
+  methods SET_CELL_BUTTON
+    importing
+      value(IV_FIELDNAME) type FIELDNAME
+      value(IV_ROW) type LVC_S_ROID-ROW_ID
+    returning
+      value(R_FALV) type ref to ZCL_FALV .
+  methods SET_CELL_COLOR
+    importing
+      value(IV_FIELDNAME) type FIELDNAME
+      value(IV_COLOR) type LVC_S_COLO
+      value(IV_ROW) type LVC_S_ROID-ROW_ID
+    returning
+      value(R_FALV) type ref to ZCL_FALV .
+  methods SET_CELL_DISABLED
+    importing
+      value(IV_FIELDNAME) type FIELDNAME
+      value(IV_ROW) type LVC_S_ROID-ROW_ID
+    returning
+      value(R_FALV) type ref to ZCL_FALV .
+  methods SET_CELL_ENABLED
+    importing
+      value(IV_FIELDNAME) type FIELDNAME
+      value(IV_ROW) type LVC_S_ROID-ROW_ID
+    returning
+      value(R_FALV) type ref to ZCL_FALV .
+  methods SET_CELL_HOTSPOT
+    importing
+      value(IV_FIELDNAME) type FIELDNAME
+      value(IV_ROW) type LVC_S_ROID-ROW_ID
+    returning
+      value(R_FALV) type ref to ZCL_FALV .
 *  methods Z_DISPLAY .
-    methods set_cell_style
-      importing
-        !row    type i optional
-        !col    type i optional
-        !style  type lvc_style
-        !style2 type lvc_style optional .
-    methods set_fixed_col_row
-      importing
-        !col type i
-        !row type i .
-    methods init_cell_styles .
+  methods SET_CELL_STYLE
+    importing
+      !ROW type I optional
+      !COL type I optional
+      !STYLE type LVC_STYLE
+      !STYLE2 type LVC_STYLE optional .
+  methods SET_DUMMY_FUNCTION_CODE
+    returning
+      value(R_FALV) type ref to ZCL_FALV .
+  methods SET_EDITABLE
+    importing
+      value(IV_MODIFY) type ABAP_BOOL default ABAP_FALSE
+    returning
+      value(R_FALV) type ref to ZCL_FALV .
+  methods SET_FIXED_COL_ROW
+    importing
+      !COL type I
+      !ROW type I .
+  methods SET_LIST_VIEW
+    returning
+      value(R_FALV) type ref to ZCL_FALV .
+  methods SET_MARK_FIELD
+    importing
+      value(IV_FIELDNAME) type LVC_S_FCAT-FIELDNAME
+    returning
+      value(R_FALV) type ref to ZCL_FALV .
+  methods SET_MERGE_HORIZONTALLY
+    importing
+      !ROW type I
+      !TAB_COL_MERGE type LVC_T_CO01 .
+  methods SET_MERGE_VERTICALLY
+    importing
+      !ROW type I
+      !TAB_COL_MERGE type LVC_T_CO01 .
+  methods SET_OUTPUT_TABLE
+    changing
+      !CT_TABLE type STANDARD TABLE .
+  methods SET_READONLY
+    returning
+      value(R_FALV) type ref to ZCL_FALV .
+  methods SET_ROW_COLOR
+    importing
+      value(IV_COLOR) type CHAR04
+      value(IV_ROW) type LVC_S_ROID-ROW_ID
+    returning
+      value(R_FALV) type ref to ZCL_FALV .
+  methods SHOW_APPLOG
+    returning
+      value(R_FALV) type ref to ZCL_FALV .
+  methods SHOW_TOP_OF_PAGE
+    returning
+      value(R_FALV) type ref to ZCL_FALV .
+  methods SOFT_REFRESH
+    returning
+      value(R_FALV) type ref to ZCL_FALV .
 
-    methods redraw_after_merging_change.
-  protected section.
+  methods SET_FRONTEND_FIELDCATALOG
+    redefinition .
+  methods SET_FRONTEND_LAYOUT
+    redefinition .
+protected section.
 
+  data TOOLBAR_ADDED type TTB_BUTTON .
+  data TOOLBAR_DELETED type TTB_BUTTON .
+  data TOOLBAR_DISABLED type TTB_BUTTON .
+  data TOOLBAR_EXCEPTIONS type TTB_BUTTON .
+  data:
+    columns type sorted table of t_column with unique key table_line .
+  data APPLICATION_LOG_EMBEDDED type ABAP_BOOL .
+  data SUBCLASS_TYPE type ref to CL_ABAP_TYPEDESCR .
 
-    data: toolbar_added      type ttb_button,
-          toolbar_deleted    type ttb_button,
-          toolbar_disabled   type ttb_button,
-          toolbar_exceptions type ttb_button.
-    data:
-      columns type sorted table of t_column with unique key table_line .
-
-    data application_log_embedded type abap_bool .
-    data subclass_type type ref to cl_abap_typedescr .
-
-    events at_set_pf_status .
-    events at_set_title .
+  events AT_SET_PF_STATUS .
+  events AT_SET_TITLE .
     "! Event called just after method <strong>SET_TABLE_FOR_FIRST_DISPLAY</strong> is called internally.
     "! Can be used for example to setup merging of cells
-    events before_first_display.
+  events BEFORE_FIRST_DISPLAY .
 
-    methods evf_before_first_display for event before_first_display of zcl_falv.
-    methods evf_btn_click
-      for event button_click of cl_gui_alv_grid
-      importing
-        !es_col_id
-        !es_row_no ##NEEDED.
-    methods evf_user_command
-      for event user_command of cl_gui_alv_grid
-      importing
-        !e_ucomm ##NEEDED.
-    methods evf_hotspot_click
-      for event hotspot_click of cl_gui_alv_grid
-      importing
-        !e_row_id
-        !e_column_id
-        !es_row_no ##NEEDED.
-    methods evf_data_changed
-      for event data_changed of cl_gui_alv_grid
-      importing
-        !er_data_changed
-        !e_onf4
-        !e_onf4_before
-        !e_onf4_after
-        !e_ucomm ##NEEDED.
-    methods evf_data_changed_finished
-      for event data_changed_finished of cl_gui_alv_grid
-      importing
-        !e_modified
-        !et_good_cells ##NEEDED.
-    methods evf_double_click
-      for event double_click of cl_gui_alv_grid
-      importing
-        !e_row
-        !e_column
-        !es_row_no ##NEEDED.
-    methods evf_onf1
-      for event onf1 of cl_gui_alv_grid
-      importing
-        !e_fieldname
-        !es_row_no
-        !er_event_data ##NEEDED.
-    methods evf_onf4
-      for event onf4 of cl_gui_alv_grid
-      importing
-        !e_fieldname
-        !e_fieldvalue
-        !es_row_no
-        !er_event_data
-        !et_bad_cells
-        !e_display ##NEEDED.
-    methods evf_subtotal_text
-      for event subtotal_text of cl_gui_alv_grid
-      importing
-        !es_subtottxt_info
-        !ep_subtot_line
-        !e_event_data ##NEEDED.
-    methods evf_before_user_command
-      for event before_user_command of cl_gui_alv_grid
-      importing
-        !e_ucomm ##NEEDED.
-    methods evf_after_user_command
-      for event after_user_command of cl_gui_alv_grid
-      importing
-        !e_ucomm
-        !e_saved
-        !e_not_processed ##NEEDED.
-    methods evf_menu_button
-      for event menu_button of cl_gui_alv_grid
-      importing
-        !e_object
-        !e_ucomm ##NEEDED.
-    methods evf_toolbar
-      for event toolbar of cl_gui_alv_grid
-      importing
-        !e_object
-        !e_interactive ##NEEDED.
-    methods evf_after_refresh
-        for event after_refresh of cl_gui_alv_grid .
-    methods evf_top_of_page
-      for event top_of_page of cl_gui_alv_grid
-      importing
-        !e_dyndoc_id
-        !table_index ##NEEDED.
-    methods evf_delayed_callback
-        for event delayed_callback of cl_gui_alv_grid .
-    methods evf_delayed_changed_sel_call
-        for event delayed_changed_sel_callback of cl_gui_alv_grid .
-    methods evf_ondropgetflavor
-      for event ondropgetflavor of cl_gui_alv_grid
-      importing
-        !es_row_no
-        !e_column
-        !e_dragdropobj
-        !e_flavors
-        !e_row ##NEEDED.
-    methods evf_ondrag
-      for event ondrag of cl_gui_alv_grid
-      importing
-        !es_row_no
-        !e_column
-        !e_dragdropobj
-        !e_row ##NEEDED.
-    methods evf_ondrop
-      for event ondrop of cl_gui_alv_grid
-      importing
-        !es_row_no
-        !e_column
-        !e_dragdropobj
-        !e_row ##NEEDED.
-    methods evf_ondropcomplete
-      for event ondropcomplete of cl_gui_alv_grid
-      importing
-        !es_row_no
-        !e_column
-        !e_dragdropobj
-        !e_row ##NEEDED.
-    methods evf_drop_external_file
-      for event drop_external_files of cl_gui_alv_grid
-      importing
-        !files ##NEEDED.
-    methods evf_toolbar_menubutton_click
-      for event toolbar_menubutton_click of cl_gui_alv_grid
-      importing
-        !fcode
-        !menu_pos_x
-        !menu_pos_y ##NEEDED.
-    methods evf_click_col_header
-      for event click_col_header of cl_gui_alv_grid
-      importing
-        !col_id ##NEEDED.
-    methods evf_delayed_move_current_cell
-        for event delayed_move_current_cell of cl_gui_alv_grid .
-    methods evf_f1
-        for event f1 of cl_gui_alv_grid .
-    methods evf_dblclick_row_col
-      for event dblclick_row_col of cl_gui_alv_grid
-      importing
-        !col_id
-        !row_id ##NEEDED.
-    methods evf_click_row_col
-      for event click_row_col of cl_gui_alv_grid
-      importing
-        !col_id
-        !row_id ##NEEDED.
-    methods evf_toolbar_button_click
-      for event toolbar_button_click of cl_gui_alv_grid
-      importing
-        !fcode ##NEEDED.
-    methods evf_double_click_col_separator
-      for event double_click_col_separator of cl_gui_alv_grid
-      importing
-        !col_id ##NEEDED.
-    methods evf_delayed_change_selection
-        for event delayed_change_selection of cl_gui_alv_grid .
-    methods evf_context_menu
-        for event context_menu of cl_gui_alv_grid .
-    methods evf_context_menu_request
-      for event context_menu_request of cl_gui_alv_grid
-      importing
-        !e_object.
-    methods evf_total_click_row_col
-      for event total_click_row_col of cl_gui_alv_grid
-      importing
-        !col_id
-        !row_id ##NEEDED.
-    methods evf_context_menu_selected
-      for event context_menu_selected of cl_gui_alv_grid
-      importing
-        !fcode ##NEEDED.
-    methods evf_toolbar_menu_selected
-      for event toolbar_menu_selected of cl_gui_alv_grid
-      importing
-        !fcode ##NEEDED.
-    methods evf_request_data
-      for event _request_data of cl_gui_alv_grid
-      importing
-        !fragments ##NEEDED.
-    methods evf_at_set_pf_status
-        for event at_set_pf_status of zcl_falv .
-    methods evf_at_set_title
-        for event at_set_title of zcl_falv .
-  private section.
+  methods EVF_AFTER_REFRESH
+    for event AFTER_REFRESH of CL_GUI_ALV_GRID .
+  methods EVF_AFTER_USER_COMMAND
+    for event AFTER_USER_COMMAND of CL_GUI_ALV_GRID
+    importing
+      !E_UCOMM
+      !E_SAVED
+      !E_NOT_PROCESSED  ##NEEDED.
+  methods EVF_AT_SET_PF_STATUS
+    for event AT_SET_PF_STATUS of ZCL_FALV .
+  methods EVF_AT_SET_TITLE
+    for event AT_SET_TITLE of ZCL_FALV .
+  methods EVF_BEFORE_FIRST_DISPLAY
+    for event BEFORE_FIRST_DISPLAY of ZCL_FALV .
+  methods EVF_BEFORE_USER_COMMAND
+    for event BEFORE_USER_COMMAND of CL_GUI_ALV_GRID
+    importing
+      !E_UCOMM  ##NEEDED.
+  methods EVF_BTN_CLICK
+    for event BUTTON_CLICK of CL_GUI_ALV_GRID
+    importing
+      !ES_COL_ID
+      !ES_ROW_NO  ##NEEDED.
+  methods EVF_CLICK_COL_HEADER
+    for event CLICK_COL_HEADER of CL_GUI_ALV_GRID
+    importing
+      !COL_ID  ##NEEDED.
+  methods EVF_CLICK_ROW_COL
+    for event CLICK_ROW_COL of CL_GUI_ALV_GRID
+    importing
+      !COL_ID
+      !ROW_ID  ##NEEDED.
+  methods EVF_CONTEXT_MENU
+    for event CONTEXT_MENU of CL_GUI_ALV_GRID .
+  methods EVF_CONTEXT_MENU_REQUEST
+    for event CONTEXT_MENU_REQUEST of CL_GUI_ALV_GRID
+    importing
+      !E_OBJECT .
+  methods EVF_CONTEXT_MENU_SELECTED
+    for event CONTEXT_MENU_SELECTED of CL_GUI_ALV_GRID
+    importing
+      !FCODE  ##NEEDED.
+  methods EVF_DATA_CHANGED
+    for event DATA_CHANGED of CL_GUI_ALV_GRID
+    importing
+      !ER_DATA_CHANGED
+      !E_ONF4
+      !E_ONF4_BEFORE
+      !E_ONF4_AFTER
+      !E_UCOMM  ##NEEDED.
+  methods EVF_DATA_CHANGED_FINISHED
+    for event DATA_CHANGED_FINISHED of CL_GUI_ALV_GRID
+    importing
+      !E_MODIFIED
+      !ET_GOOD_CELLS  ##NEEDED.
+  methods EVF_DBLCLICK_ROW_COL
+    for event DBLCLICK_ROW_COL of CL_GUI_ALV_GRID
+    importing
+      !COL_ID
+      !ROW_ID  ##NEEDED.
+  methods EVF_DELAYED_CALLBACK
+    for event DELAYED_CALLBACK of CL_GUI_ALV_GRID .
+  methods EVF_DELAYED_CHANGED_SEL_CALL
+    for event DELAYED_CHANGED_SEL_CALLBACK of CL_GUI_ALV_GRID .
+  methods EVF_DELAYED_CHANGE_SELECTION
+    for event DELAYED_CHANGE_SELECTION of CL_GUI_ALV_GRID .
+  methods EVF_DELAYED_MOVE_CURRENT_CELL
+    for event DELAYED_MOVE_CURRENT_CELL of CL_GUI_ALV_GRID .
+  methods EVF_DOUBLE_CLICK
+    for event DOUBLE_CLICK of CL_GUI_ALV_GRID
+    importing
+      !E_ROW
+      !E_COLUMN
+      !ES_ROW_NO  ##NEEDED.
+  methods EVF_DOUBLE_CLICK_COL_SEPARATOR
+    for event DOUBLE_CLICK_COL_SEPARATOR of CL_GUI_ALV_GRID
+    importing
+      !COL_ID  ##NEEDED.
+  methods EVF_DROP_EXTERNAL_FILE
+    for event DROP_EXTERNAL_FILES of CL_GUI_ALV_GRID
+    importing
+      !FILES  ##NEEDED.
+  methods EVF_F1
+    for event F1 of CL_GUI_ALV_GRID .
+  methods EVF_HOTSPOT_CLICK
+    for event HOTSPOT_CLICK of CL_GUI_ALV_GRID
+    importing
+      !E_ROW_ID
+      !E_COLUMN_ID
+      !ES_ROW_NO  ##NEEDED.
+  methods EVF_MENU_BUTTON
+    for event MENU_BUTTON of CL_GUI_ALV_GRID
+    importing
+      !E_OBJECT
+      !E_UCOMM  ##NEEDED.
+  methods EVF_ONDRAG
+    for event ONDRAG of CL_GUI_ALV_GRID
+    importing
+      !ES_ROW_NO
+      !E_COLUMN
+      !E_DRAGDROPOBJ
+      !E_ROW  ##NEEDED.
+  methods EVF_ONDROP
+    for event ONDROP of CL_GUI_ALV_GRID
+    importing
+      !ES_ROW_NO
+      !E_COLUMN
+      !E_DRAGDROPOBJ
+      !E_ROW  ##NEEDED.
+  methods EVF_ONDROPCOMPLETE
+    for event ONDROPCOMPLETE of CL_GUI_ALV_GRID
+    importing
+      !ES_ROW_NO
+      !E_COLUMN
+      !E_DRAGDROPOBJ
+      !E_ROW  ##NEEDED.
+  methods EVF_ONDROPGETFLAVOR
+    for event ONDROPGETFLAVOR of CL_GUI_ALV_GRID
+    importing
+      !ES_ROW_NO
+      !E_COLUMN
+      !E_DRAGDROPOBJ
+      !E_FLAVORS
+      !E_ROW  ##NEEDED.
+  methods EVF_ONF1
+    for event ONF1 of CL_GUI_ALV_GRID
+    importing
+      !E_FIELDNAME
+      !ES_ROW_NO
+      !ER_EVENT_DATA  ##NEEDED.
+  methods EVF_ONF4
+    for event ONF4 of CL_GUI_ALV_GRID
+    importing
+      !E_FIELDNAME
+      !E_FIELDVALUE
+      !ES_ROW_NO
+      !ER_EVENT_DATA
+      !ET_BAD_CELLS
+      !E_DISPLAY  ##NEEDED.
+  methods EVF_REQUEST_DATA
+    for event _REQUEST_DATA of CL_GUI_ALV_GRID
+    importing
+      !FRAGMENTS  ##NEEDED.
+  methods EVF_SUBTOTAL_TEXT
+    for event SUBTOTAL_TEXT of CL_GUI_ALV_GRID
+    importing
+      !ES_SUBTOTTXT_INFO
+      !EP_SUBTOT_LINE
+      !E_EVENT_DATA  ##NEEDED.
+  methods EVF_TOOLBAR
+    for event TOOLBAR of CL_GUI_ALV_GRID
+    importing
+      !E_OBJECT
+      !E_INTERACTIVE  ##NEEDED.
+  methods EVF_TOOLBAR_BUTTON_CLICK
+    for event TOOLBAR_BUTTON_CLICK of CL_GUI_ALV_GRID
+    importing
+      !FCODE  ##NEEDED.
+  methods EVF_TOOLBAR_MENUBUTTON_CLICK
+    for event TOOLBAR_MENUBUTTON_CLICK of CL_GUI_ALV_GRID
+    importing
+      !FCODE
+      !MENU_POS_X
+      !MENU_POS_Y  ##NEEDED.
+  methods EVF_TOOLBAR_MENU_SELECTED
+    for event TOOLBAR_MENU_SELECTED of CL_GUI_ALV_GRID
+    importing
+      !FCODE  ##NEEDED.
+  methods EVF_TOP_OF_PAGE
+    for event TOP_OF_PAGE of CL_GUI_ALV_GRID
+    importing
+      !E_DYNDOC_ID
+      !TABLE_INDEX  ##NEEDED.
+  methods EVF_TOTAL_CLICK_ROW_COL
+    for event TOTAL_CLICK_ROW_COL of CL_GUI_ALV_GRID
+    importing
+      !COL_ID
+      !ROW_ID  ##NEEDED.
+  methods EVF_USER_COMMAND
+    for event USER_COMMAND of CL_GUI_ALV_GRID
+    importing
+      !E_UCOMM  ##NEEDED.
+private section.
 
-    class-data: created_from_factory type abap_bool.
-    data top_of_page_doc type ref to cl_dd_document .
-    data top_of_page_visible_at_start type abap_bool .
-    data call_redraw_after_merging type abap_bool.
+  class-data CREATED_FROM_FACTORY type ABAP_BOOL .
+  data TOP_OF_PAGE_DOC type ref to CL_DD_DOCUMENT .
+  data TOP_OF_PAGE_VISIBLE_AT_START type ABAP_BOOL .
+  data CALL_REDRAW_AFTER_MERGING type ABAP_BOOL .
 
-    class-methods check_if_called_from_subclass
-      returning
-        value(ro_subclass) type ref to object .
-    class-methods create_containters
-      importing
-        i_parent               type ref to cl_gui_container
-        i_applogparent         type ref to cl_gui_container
-        i_popup                type abap_bool
-        i_applog_embedded      type abap_bool
-      exporting
-        e_built_in_screen      type abap_bool
-        e_parent               type ref to cl_gui_container
-        e_applog               type ref to cl_gui_container
-        e_top_of_page_parent   type ref to cl_gui_container
-        e_custom_container     type ref to cl_gui_container
-        e_main_split_container type ref to cl_gui_splitter_container
-        e_split_container      type ref to cl_gui_splitter_container.
-    class-methods create_falv_object
-      importing
-        i_subclass     type ref to cl_abap_typedescr
-        i_parent       type ref to cl_gui_container
-        i_applog       type ref to cl_gui_container
-      returning
-        value(rv_falv) type ref to zcl_falv.
-    class-methods link_containers
-      importing
-        iv_falv                type ref to zcl_falv
-        i_top_of_page_parent   type ref to cl_gui_container
-        i_custom_container     type ref to cl_gui_container
-        i_main_split_container type ref to cl_gui_splitter_container
-        i_split_container      type ref to cl_gui_splitter_container.
-    class-methods create_main_split_cotainer
-      importing
-        i_popup                       type abap_bool
-        i_applog_embedded             type abap_bool
-        i_main_parent                 type ref to cl_gui_container
-      returning
-        value(r_main_split_container) type ref to cl_gui_splitter_container.
-    class-methods create_main_cont_for_full_scr
-      importing
-        i_popup                   type abap_bool
-      returning
-        value(r_custom_container) type ref to cl_gui_container.
-    class-methods crate_main_splitter
-      importing
-        i_main_split_container   type ref to cl_gui_splitter_container
-      returning
-        value(r_split_container) type ref to cl_gui_splitter_container.
-
-    methods evf_before_ucommand_internal
-      for event before_user_command of cl_gui_alv_grid
-      importing
-        !e_ucomm ##NEEDED.
-    methods evf_toolbar_internal
-      for event toolbar of cl_gui_alv_grid
-      importing
-        !e_object
-        !e_interactive ##NEEDED.
-    methods evf_data_changed_internal
-      for event data_changed of cl_gui_alv_grid
-      importing
-        !er_data_changed
-        !e_onf4
-        !e_onf4_before
-        !e_onf4_after
-        !e_ucomm ##NEEDED.
-
-    methods set_parent
-      importing
-        !io_parent    type ref to object
-      returning
-        value(r_falv) type ref to zcl_falv .
-    methods build_columns .
-    methods raise_top_of_page .
-    methods set_handlers
-      importing
-        iv_falv type ref to zcl_falv.
-    methods copy_attributes
-      importing
-        i_falv type ref to zcl_falv.
-    methods create_ex_result_falv
-      returning
-        value(er_result_table) type ref to cl_salv_ex_result_data_table .
-    methods raise_before_first_display.
-endclass.
-
+  class-methods CHECK_IF_CALLED_FROM_SUBCLASS
+    returning
+      value(RO_SUBCLASS) type ref to OBJECT .
+  class-methods CRATE_MAIN_SPLITTER
+    importing
+      !I_MAIN_SPLIT_CONTAINER type ref to CL_GUI_SPLITTER_CONTAINER
+    returning
+      value(R_SPLIT_CONTAINER) type ref to CL_GUI_SPLITTER_CONTAINER .
+  class-methods CREATE_CONTAINTERS
+    importing
+      !I_PARENT type ref to CL_GUI_CONTAINER
+      !I_APPLOGPARENT type ref to CL_GUI_CONTAINER
+      !I_POPUP type ABAP_BOOL
+      !I_APPLOG_EMBEDDED type ABAP_BOOL
+    exporting
+      !E_BUILT_IN_SCREEN type ABAP_BOOL
+      !E_PARENT type ref to CL_GUI_CONTAINER
+      !E_APPLOG type ref to CL_GUI_CONTAINER
+      !E_TOP_OF_PAGE_PARENT type ref to CL_GUI_CONTAINER
+      !E_CUSTOM_CONTAINER type ref to CL_GUI_CONTAINER
+      !E_MAIN_SPLIT_CONTAINER type ref to CL_GUI_SPLITTER_CONTAINER
+      !E_SPLIT_CONTAINER type ref to CL_GUI_SPLITTER_CONTAINER .
+  class-methods CREATE_FALV_OBJECT
+    importing
+      !I_SUBCLASS type ref to CL_ABAP_TYPEDESCR
+      !I_PARENT type ref to CL_GUI_CONTAINER
+      !I_APPLOG type ref to CL_GUI_CONTAINER
+    returning
+      value(RV_FALV) type ref to ZCL_FALV .
+  class-methods CREATE_MAIN_CONT_FOR_FULL_SCR
+    importing
+      !I_POPUP type ABAP_BOOL
+    returning
+      value(R_CUSTOM_CONTAINER) type ref to CL_GUI_CONTAINER .
+  class-methods CREATE_MAIN_SPLIT_COTAINER
+    importing
+      !I_POPUP type ABAP_BOOL
+      !I_APPLOG_EMBEDDED type ABAP_BOOL
+      !I_MAIN_PARENT type ref to CL_GUI_CONTAINER
+    returning
+      value(R_MAIN_SPLIT_CONTAINER) type ref to CL_GUI_SPLITTER_CONTAINER .
+  class-methods LINK_CONTAINERS
+    importing
+      !IV_FALV type ref to ZCL_FALV
+      !I_TOP_OF_PAGE_PARENT type ref to CL_GUI_CONTAINER
+      !I_CUSTOM_CONTAINER type ref to CL_GUI_CONTAINER
+      !I_MAIN_SPLIT_CONTAINER type ref to CL_GUI_SPLITTER_CONTAINER
+      !I_SPLIT_CONTAINER type ref to CL_GUI_SPLITTER_CONTAINER .
+  methods BUILD_COLUMNS .
+  methods COPY_ATTRIBUTES
+    importing
+      !I_FALV type ref to ZCL_FALV .
+  methods CREATE_EX_RESULT_FALV
+    returning
+      value(ER_RESULT_TABLE) type ref to CL_SALV_EX_RESULT_DATA_TABLE .
+  methods EVF_BEFORE_UCOMMAND_INTERNAL
+    for event BEFORE_USER_COMMAND of CL_GUI_ALV_GRID
+    importing
+      !E_UCOMM  ##NEEDED.
+  methods EVF_DATA_CHANGED_INTERNAL
+    for event DATA_CHANGED of CL_GUI_ALV_GRID
+    importing
+      !ER_DATA_CHANGED
+      !E_ONF4
+      !E_ONF4_BEFORE
+      !E_ONF4_AFTER
+      !E_UCOMM  ##NEEDED.
+  methods EVF_TOOLBAR_INTERNAL
+    for event TOOLBAR of CL_GUI_ALV_GRID
+    importing
+      !E_OBJECT
+      !E_INTERACTIVE  ##NEEDED.
+  methods RAISE_BEFORE_FIRST_DISPLAY .
+  methods RAISE_TOP_OF_PAGE .
+  methods SET_HANDLERS
+    importing
+      !IV_FALV type ref to ZCL_FALV .
+  methods SET_PARENT
+    importing
+      !IO_PARENT type ref to OBJECT
+    returning
+      value(R_FALV) type ref to ZCL_FALV .
+ENDCLASS.
 
 
-class zcl_falv implementation.
+
+CLASS ZCL_FALV IMPLEMENTATION.
 
 
   method add_button.
@@ -1343,6 +1367,7 @@ class zcl_falv implementation.
     endif.
   endmethod.
 
+
   method raise_before_first_display.
 
     raise event before_first_display.
@@ -1350,8 +1375,6 @@ class zcl_falv implementation.
       redraw_after_merging_change( ).
     endif.
   endmethod.
-
-
 
 
   method enable_button.
@@ -2584,6 +2607,7 @@ class zcl_falv implementation.
     ).
   endmethod.
 
+
   method init_cell_styles.
 * https://tricktresor.de/blog/zellen-verbinden/
     field-symbols <data> type lvc_s_data.
@@ -2720,7 +2744,7 @@ class zcl_falv implementation.
 * und das mergekennzeichen muss auch weg !
         else.
           clear <data>-mergevert.
-          clear <data>-value.
+****************          clear <data>-value.
         endif.
       endloop.
 
@@ -2728,9 +2752,12 @@ class zcl_falv implementation.
     endloop.
 
   endmethod.
+
+
   method evf_before_first_display ##NEEDED.
 
   endmethod.
+
 
   method redraw_after_merging_change.
 * https://tricktresor.de/blog/zellen-verbinden/
@@ -2738,5 +2765,4 @@ class zcl_falv implementation.
     set_auto_redraw( enable = 1 ).
 
   endmethod.
-
-endclass.
+ENDCLASS.

--- a/CODE/zcl_falv_column.clas.abap
+++ b/CODE/zcl_falv_column.clas.abap
@@ -1101,11 +1101,12 @@ CLASS ZCL_FALV_COLUMN IMPLEMENTATION.
           ,ls_drop_down        LIKE LINE OF lt_drop_down
           ,lt_drop_down_alias  TYPE	lvc_t_dral
           ,ls_drop_down_alias  LIKE LINE OF lt_drop_down_alias
-*          ,lo_typedescr        TYPE REF TO cl_abap_typedescr
-*          ,lo_elemdescr        TYPE REF TO cl_abap_elemdescr
-          ,lo_domadescr        TYPE REF TO cl_abap_cc_domain
-          ,lt_obj_values       TYPE if_abap_cc_properties=>ty_values_seq
-          ,ls_obj_value        LIKE LINE OF lt_obj_values
+          ,lo_typedescr        TYPE REF TO cl_abap_typedescr
+          ,lo_elemdescr        TYPE REF TO cl_abap_elemdescr
+*          ,lo_domadescr        TYPE REF TO cl_abap_cc_domain
+*          ,lt_obj_values       TYPE if_abap_cc_properties=>ty_values_seq
+*          ,ls_obj_value        LIKE LINE OF lt_obj_values
+          ,lv_rollname         TYPE lvc_roll
           ,lv_domname          TYPE domname
           ,lt_fixed_values     TYPE cl_abap_elemdescr=>fixvalues
           ,ls_fixed_value      LIKE LINE OF lt_fixed_values
@@ -1120,82 +1121,84 @@ CLASS ZCL_FALV_COLUMN IMPLEMENTATION.
 
     ELSE.
       IF ( iv_use_domain_values EQ abap_true ).
-        lv_domname = me->get_domname( ).
 
+*        lv_domname = me->get_domname( ).
 
-        CREATE OBJECT lo_domadescr
-          EXPORTING
-            domname = lv_domname.
-
-
-*        CALL METHOD cl_abap_elemdescr=>describe_by_name
+*        CREATE OBJECT lo_domadescr
 *          EXPORTING
-*            p_name         = lv_data_element_name
-*          RECEIVING
-*            p_descr_ref    = lo_typedescr
-*          EXCEPTIONS
-*            type_not_found = 1
-*            OTHERS         = 2.
-*        IF sy-subrc EQ 0.
-*          lo_elemdescr ?= lo_typedescr.
+*            domname = lv_domname.
 
-*        get_ddic_fixed_values
-*        CALL METHOD lo_elemdescr->get_ddic_fixed_values
-**  EXPORTING
-**    p_langu        = SY-LANGU
-*          RECEIVING
-*            p_fixed_values = lt_fixed_values
-**  EXCEPTIONS
-**           not_found      = 1
-**           no_ddic_type   = 2
-**           others         = 3
-*          .
+
+        lv_rollname = me->get_rollname( ).
+
+        CALL METHOD cl_abap_elemdescr=>describe_by_name
+          EXPORTING
+            p_name         = lv_rollname
+          RECEIVING
+            p_descr_ref    = lo_typedescr
+          EXCEPTIONS
+            type_not_found = 1
+            OTHERS         = 2.
         IF sy-subrc EQ 0.
+          lo_elemdescr ?= lo_typedescr.
+
+*          get_ddic_fixed_values
+          CALL METHOD lo_elemdescr->get_ddic_fixed_values
+*  EXPORTING
+*    p_langu        = SY-LANGU
+            RECEIVING
+              p_fixed_values = lt_fixed_values
+*  EXCEPTIONS
+*             not_found      = 1
+*             no_ddic_type   = 2
+*             others         = 3
+            .
+          IF sy-subrc EQ 0.
 
 
-          lt_obj_values = lo_domadescr->values.
+*            lt_obj_values = lo_domadescr->values.
 
-*          LOOP AT lt_fixed_values INTO ls_fixed_value.
-          LOOP AT lt_obj_values INTO ls_obj_value.
+            LOOP AT lt_fixed_values INTO ls_fixed_value.
+*            LOOP AT lt_obj_values INTO ls_obj_value.
 
 
-            IF ( iv_use_alias EQ abap_true ).
-              CLEAR: ls_drop_down_alias.
+              IF ( iv_use_alias EQ abap_true ).
+                CLEAR: ls_drop_down_alias.
 
-              ls_drop_down_alias-handle = iv_value.
+                ls_drop_down_alias-handle = iv_value.
 *              ls_drop_down_alias-value = ls_fixed_value-ddtext.
-*              CONCATENATE ls_fixed_value-ddtext '['
-              CONCATENATE ls_obj_value->sourcetext '['
-                INTO ls_drop_down_alias-value SEPARATED BY space.
+                CONCATENATE ls_fixed_value-ddtext '['
+*                CONCATENATE ls_obj_value->sourcetext '['
+                    INTO ls_drop_down_alias-value SEPARATED BY space.
 
-              CONCATENATE ls_drop_down_alias-value
-*                           ls_fixed_value-low ']'
-                           ls_obj_value->value ']'
-                INTO ls_drop_down_alias-value.
+                CONCATENATE ls_drop_down_alias-value
+                           ls_fixed_value-low ']'
+*                             ls_obj_value->value ']'
+                  INTO ls_drop_down_alias-value.
 
-*              ls_drop_down_alias-int_value = ls_fixed_value-low.
-              ls_drop_down_alias-int_value = ls_obj_value->value.
+                ls_drop_down_alias-int_value = ls_fixed_value-low.
+*                ls_drop_down_alias-int_value = ls_obj_value->value.
 
-              APPEND ls_drop_down_alias TO lt_drop_down_alias.
-            ELSE.
-              CLEAR: ls_drop_down.
+                APPEND ls_drop_down_alias TO lt_drop_down_alias.
+              ELSE.
+                CLEAR: ls_drop_down.
 
-              ls_drop_down-handle = iv_value.
-*              ls_drop_down-value = ls_fixed_value-low.
-              ls_drop_down-value = ls_obj_value->value.
+                ls_drop_down-handle = iv_value.
+                ls_drop_down-value = ls_fixed_value-low.
+*                ls_drop_down-value = ls_obj_value->value.
 
-              APPEND ls_drop_down TO lt_drop_down.
-            ENDIF.
+                APPEND ls_drop_down TO lt_drop_down.
+              ENDIF.
 
-          ENDLOOP.
+            ENDLOOP.
 
 
 
-        ELSE.
+          ELSE.
 * Implement suitable error handling here
-        ENDIF.
+          ENDIF.
 
-*      ENDIF.
+        ENDIF.
       ELSE.
 *                Implement suitable error handling here
       ENDIF.

--- a/CODE/zcl_falv_column.clas.abap
+++ b/CODE/zcl_falv_column.clas.abap
@@ -1,794 +1,908 @@
-class zcl_falv_column definition
+class ZCL_FALV_COLUMN definition
   public
   create public .
 
-  public section.
+public section.
 
-    data fieldname type lvc_s_fcat-fieldname read-only .
+  data FIELDNAME type LVC_S_FCAT-FIELDNAME read-only .
 
-    methods constructor
-      importing
-        value(iv_fieldname) type lvc_s_fcat-fieldname
-        !io_falv            type ref to zcl_falv .
-    methods set_editable returning value(r_column) type ref to zcl_falv_column.
-    methods set_readonly returning value(r_column) type ref to zcl_falv_column.
-    methods set_row_pos
-      importing
-                value(iv_value) type lvc_rowpos
-      returning value(r_column) type ref to zcl_falv_column.
-    methods set_col_pos
-      importing
-                value(iv_value) type lvc_colpos
-      returning value(r_column) type ref to zcl_falv_column.
-    methods set_fieldname
-      importing
-                value(iv_value) type lvc_fname
-      returning value(r_column) type ref to zcl_falv_column.
-    methods set_tabname
-      importing
-                value(iv_value) type lvc_tname
-      returning value(r_column) type ref to zcl_falv_column.
-    methods set_currency
-      importing
-                value(iv_value) type lvc_curr
-      returning value(r_column) type ref to zcl_falv_column.
-    methods set_cfieldname
-      importing
-                value(iv_value) type lvc_cfname
-      returning value(r_column) type ref to zcl_falv_column.
-    methods set_quantity
-      importing
-                value(iv_value) type lvc_quan
-      returning value(r_column) type ref to zcl_falv_column.
-    methods set_qfieldname
-      importing
-                value(iv_value) type lvc_qfname
-      returning value(r_column) type ref to zcl_falv_column.
-    methods set_ifieldname
-      importing
-                value(iv_value) type lvc_fname
-      returning value(r_column) type ref to zcl_falv_column.
-    methods set_round
-      importing
-                value(iv_value) type lvc_round
-      returning value(r_column) type ref to zcl_falv_column..
-    methods set_exponent
-      importing
-                value(iv_value) type lvc_expont
-      returning value(r_column) type ref to zcl_falv_column.
-    methods set_key
-      importing
-                value(iv_value) type lvc_key
-      returning value(r_column) type ref to zcl_falv_column.
-    methods set_key_sel
-      importing
-                value(iv_value) type lvc_keysel
-      returning value(r_column) type ref to zcl_falv_column.
-    methods set_icon
-      importing
-                value(iv_value) type lvc_icon
-      returning value(r_column) type ref to zcl_falv_column.
-    methods set_symbol
-      importing
-                value(iv_value) type lvc_symbol
-      returning value(r_column) type ref to zcl_falv_column.
-    methods set_checkbox
-      importing
-                value(iv_value) type lvc_checkb
-      returning value(r_column) type ref to zcl_falv_column.
-    methods set_just
-      importing
-                value(iv_value) type lvc_just
-      returning value(r_column) type ref to zcl_falv_column.
-    methods set_lzero
-      importing
-                value(iv_value) type lvc_lzero
-      returning value(r_column) type ref to zcl_falv_column.
-    methods set_no_sign
-      importing
-                value(iv_value) type lvc_nosign
-      returning value(r_column) type ref to zcl_falv_column.
-    methods set_no_zero
-      importing
-                value(iv_value) type lvc_nozero
-      returning value(r_column) type ref to zcl_falv_column.
-    methods set_no_convext
-      importing
-                value(iv_value) type lvc_noconv
-      returning value(r_column) type ref to zcl_falv_column.
-    methods set_edit_mask
-      importing
-        value(iv_value) type lvc_edtmsk
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_emphasize
-      importing
-        value(iv_value) type lvc_emphsz
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_color
-      importing
-        value(iv_value) type lvc_emphsz
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_fix_column
-      importing
-        value(iv_value) type lvc_fixcol
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_do_sum
-      importing
-        value(iv_value) type lvc_dosum
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_no_sum
-      importing
-        value(iv_value) type lvc_nosum
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_no_out
-      importing
-        value(iv_value) type lvc_noout
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_tech
-      importing
-        value(iv_value) type lvc_tech
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_outputlen
-      importing
-        value(iv_value) type lvc_outlen
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_convexit
-      importing
-        value(iv_value) type convexit
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_seltext
-      importing
-        value(iv_value) type lvc_txt
-         returning value(r_column) type ref to zcl_falv_column.
-    methods set_tooltip
-      importing
-        value(iv_value) type lvc_tip
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_rollname
-      importing
-        value(iv_value) type lvc_roll
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_datatype
-      importing
-        value(iv_value) type datatype_d
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_inttype
-      importing
-        value(iv_value) type inttype
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_intlen
-      importing
-        value(iv_value) type intlen
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_lowercase
-      importing
-        value(iv_value) type lowercase
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_reptext
-      importing
-        value(iv_value) type reptext
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_hier_level
-      importing
-        value(iv_value) type lvc_hierl
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_reprep
-      importing
-        value(iv_value) type lvc_crprp
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_domname
-      importing
-        value(iv_value) type domname
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_sp_group
-      importing
-        value(iv_value) type lvc_spgrp
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_hotspot
-      importing
-        value(iv_value) type lvc_hotspt
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_dfieldname
-      importing
-        value(iv_value) type lvcdbgfn
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_col_id
-      importing
-        value(iv_value) type lvc_colid
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_f4availabl
-      importing
-        value(iv_value) type ddf4avail
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_auto_value
-      importing
-        value(iv_value) type lvc_auto
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_checktable
-      importing
-        value(iv_value) type tabname
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_valexi
-      importing
-        value(iv_value) type valexi
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_web_field
-      importing
-        value(iv_value) type lvc_fname
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_href_hndl
-      importing
-        value(iv_value) type int4
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_style
-      importing
-        value(iv_value) type lvc_style
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_style2
-      importing
-        value(iv_value) type lvc_style
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_style3
-      importing
-        value(iv_value) type lvc_style
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_style4
-      importing
-        value(iv_value) type lvc_style
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_drdn_hndl
-      importing
-        value(iv_value) type int4
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_drdn_field
-      importing
-        value(iv_value) type lvc_fname
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_no_merging
-      importing
-        value(iv_value) type char01
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_h_ftype
-      importing
-        value(iv_value) type lvc_ftype
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_col_opt
-      importing
-        value(iv_value) type lvc_colopt
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_no_init_ch
-      importing
-        value(iv_value) type char01
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_drdn_alias
-      importing
-        value(iv_value) type char01
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_decfloat_style
-      importing
-        value(iv_value) type outputstyle
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_parameter0
-      importing
-        value(iv_value) type char30
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_parameter1
-      importing
-        value(iv_value) type char30
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_parameter2
-      importing
-        value(iv_value) type char30
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_parameter3
-      importing
-        value(iv_value) type char30
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_parameter4
-      importing
-        value(iv_value) type char30
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_parameter5
-      importing
-        value(iv_value) type int4
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_parameter6
-      importing
-        value(iv_value) type int4
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_parameter7
-      importing
-        value(iv_value) type int4
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_parameter8
-      importing
-        value(iv_value) type int4
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_parameter9
-      importing
-        value(iv_value) type int4
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_ref_field
-      importing
-        value(iv_value) type lvc_rfname
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_ref_table
-      importing
-        value(iv_value) type lvc_rtname
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_txt_field
-      importing
-        value(iv_value) type lvc_fname
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_roundfield
-      importing
-        value(iv_value) type lvc_rndfn
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_decimals_o
-      importing
-        value(iv_value) type lvc_decmls
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_decmlfield
-      importing
-        value(iv_value) type lvc_dfname
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_dd_outlen
-      importing
-        value(iv_value) type lvc_ddlen
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_decimals
-      importing
-        value(iv_value) type decimals
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_coltext
-      importing
-        value(iv_value) type lvc_txtcol
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_scrtext_l
-      importing
-        value(iv_value) type scrtext_l
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_scrtext_m
-      importing
-        value(iv_value) type scrtext_m
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_scrtext_s
-      importing
-        value(iv_value) type scrtext_s
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_colddictxt
-      importing
-        value(iv_value) type lvc_ddict
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_selddictxt
-      importing
-        value(iv_value) type lvc_ddict
-      returning value(r_column) type ref to zcl_falv_column.
-    methods set_tipddictxt
-      importing
-        value(iv_value) type lvc_ddict
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_edit
-      importing
-        value(iv_value) type lvc_edit
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_tech_col
-      importing
-        value(iv_value) type lvc_tcol
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_tech_form
-      importing
-        value(iv_value) type lvc_tform
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_tech_comp
-      importing
-        value(iv_value) type lvc_tcomp
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_hier_cpos
-      importing
-        value(iv_value) type lvchcolpos
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_h_col_key
-      importing
-        value(iv_value) type tv_itmname
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_h_select
-      importing
-        value(iv_value) type lvc_select
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_dd_roll
-      importing
-        value(iv_value) type rollname
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_dragdropid
-      importing
-        value(iv_value) type lvc_ddid
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_mac
-      importing
-        value(iv_value) type char01
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_indx_field
-      importing
-        value(iv_value) type int4
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_indx_cfiel
-      importing
-        value(iv_value) type int4
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_indx_qfiel
-      importing
-        value(iv_value) type int4
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_indx_ifiel
-      importing
-        value(iv_value) type int4
-      returning value(r_column) type ref to zcl_falv_column.
-    methods set_indx_round
-      importing
-        value(iv_value) type int4
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_indx_decml
-      importing
-        value(iv_value) type int4
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_get_style
-      importing
-        value(iv_value) type char01
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_mark
-      importing
-        value(iv_value) type char01
-        returning value(r_column) type ref to zcl_falv_column.
-    methods set_texts
-      importing
-        value(iv_text_s) type scrtext_s
-        value(iv_text_m) type scrtext_m optional
-        value(iv_text_l) type scrtext_l optional
-        returning value(r_column) type ref to zcl_falv_column.
-
-    methods get_editable
-      returning value(rv_editable) type abap_bool.
-    methods get_readonly
-
-      returning value(rv_read_only) type abap_bool.
-    methods get_row_pos
-      returning
-        value(rv_value) type lvc_rowpos .
-    methods get_col_pos
-      returning
-        value(rv_value) type lvc_colpos .
-    methods get_fieldname
-      returning
-        value(rv_value) type lvc_fname .
-    methods get_tabname
-      returning
-        value(rv_value) type lvc_tname .
-    methods get_currency
-      returning
-        value(rv_value) type lvc_curr .
-    methods get_cfieldname
-      returning
-        value(rv_value) type lvc_cfname .
-    methods get_quantity
-      returning
-        value(rv_value) type lvc_quan .
-    methods get_qfieldname
-      returning
-        value(rv_value) type lvc_qfname .
-    methods get_ifieldname
-      returning
-        value(rv_value) type lvc_fname .
-    methods get_round
-      returning
-        value(rv_value) type lvc_round .
-    methods get_exponent
-      returning
-        value(rv_value) type lvc_expont .
-    methods get_key
-      returning
-        value(rv_value) type lvc_key .
-    methods get_key_sel
-      returning
-        value(rv_value) type lvc_keysel .
-    methods get_icon
-      returning
-        value(rv_value) type lvc_icon .
-    methods get_symbol
-      returning
-        value(rv_value) type lvc_symbol .
-    methods get_checkbox
-      returning
-        value(rv_value) type lvc_checkb .
-    methods get_just
-      returning
-        value(rv_value) type lvc_just .
-    methods get_lzero
-      returning
-        value(rv_value) type lvc_lzero .
-    methods get_no_sign
-      returning
-        value(rv_value) type lvc_nosign .
-    methods get_no_zero
-      returning
-        value(rv_value) type lvc_nozero .
-    methods get_no_convext
-      returning
-        value(rv_value) type lvc_noconv .
-    methods get_edit_mask
-      returning
-        value(rv_value) type lvc_edtmsk .
-    methods get_emphasize
-      returning
-        value(rv_value) type lvc_emphsz .
-    methods get_color
-      returning
-        value(rv_value) type lvc_emphsz .
-    methods get_fix_column
-      returning
-        value(rv_value) type lvc_fixcol .
-    methods get_do_sum
-      returning
-        value(rv_value) type lvc_dosum .
-    methods get_no_sum
-      returning
-        value(rv_value) type lvc_nosum .
-    methods get_no_out
-      returning
-        value(rv_value) type lvc_noout .
-    methods get_tech
-      returning
-        value(rv_value) type lvc_tech .
-    methods get_outputlen
-      returning
-        value(rv_value) type lvc_outlen .
-    methods get_convexit
-      returning
-        value(rv_value) type convexit .
-    methods get_seltext
-      returning
-        value(rv_value) type lvc_txt .
-    methods get_tooltip
-      returning
-        value(rv_value) type lvc_tip .
-    methods get_rollname
-      returning
-        value(rv_value) type lvc_roll .
-    methods get_datatype
-      returning
-        value(rv_value) type datatype_d .
-    methods get_inttype
-      returning
-        value(rv_value) type inttype .
-    methods get_intlen
-      returning
-        value(rv_value) type intlen .
-    methods get_lowercase
-      returning
-        value(rv_value) type lowercase .
-    methods get_reptext
-      returning
-        value(rv_value) type reptext .
-    methods get_hier_level
-      returning
-        value(rv_value) type lvc_hierl .
-    methods get_reprep
-      returning
-        value(rv_value) type lvc_crprp .
-    methods get_domname
-      returning
-        value(rv_value) type domname .
-    methods get_sp_group
-      returning
-        value(rv_value) type lvc_spgrp .
-    methods get_hotspot
-      returning
-        value(rv_value) type lvc_hotspt .
-    methods get_dfieldname
-      returning
-        value(rv_value) type lvcdbgfn .
-    methods get_col_id
-      returning
-        value(rv_value) type lvc_colid .
-    methods get_f4availabl
-      returning
-        value(rv_value) type ddf4avail .
-    methods get_auto_value
-      returning
-        value(rv_value) type lvc_auto .
-    methods get_checktable
-      returning
-        value(rv_value) type tabname .
-    methods get_valexi
-      returning
-        value(rv_value) type valexi .
-    methods get_web_field
-      returning
-        value(rv_value) type lvc_fname .
-    methods get_href_hndl
-      returning
-        value(rv_value) type int4 .
-    methods get_style
-      returning
-        value(rv_value) type lvc_style .
-    methods get_style2
-      returning
-        value(rv_value) type lvc_style .
-    methods get_style3
-      returning
-        value(rv_value) type lvc_style .
-    methods get_style4
-      returning
-        value(rv_value) type lvc_style .
-    methods get_drdn_hndl
-      returning
-        value(rv_value) type int4 .
-    methods get_drdn_field
-      returning
-        value(rv_value) type lvc_fname .
-    methods get_no_merging
-      returning
-        value(rv_value) type char01 .
-    methods get_h_ftype
-      returning
-        value(rv_value) type lvc_ftype .
-    methods get_col_opt
-      returning
-        value(rv_value) type lvc_colopt .
-    methods get_no_init_ch
-      returning
-        value(rv_value) type char01 .
-    methods get_drdn_alias
-      returning
-        value(rv_value) type char01 .
-    methods get_decfloat_style
-      returning
-        value(rv_value) type outputstyle .
-    methods get_parameter0
-      returning
-        value(rv_value) type char30 .
-    methods get_parameter1
-      returning
-        value(rv_value) type char30 .
-    methods get_parameter2
-      returning
-        value(rv_value) type char30 .
-    methods get_parameter3
-      returning
-        value(rv_value) type char30 .
-    methods get_parameter4
-      returning
-        value(rv_value) type char30 .
-    methods get_parameter5
-      returning
-        value(rv_value) type int4 .
-    methods get_parameter6
-      returning
-        value(rv_value) type int4 .
-    methods get_parameter7
-      returning
-        value(rv_value) type int4 .
-    methods get_parameter8
-      returning
-        value(rv_value) type int4 .
-    methods get_parameter9
-      returning
-        value(rv_value) type int4 .
-    methods get_ref_field
-      returning
-        value(rv_value) type lvc_rfname .
-    methods get_ref_table
-      returning
-        value(rv_value) type lvc_rtname .
-    methods get_txt_field
-      returning
-        value(rv_value) type lvc_fname .
-    methods get_roundfield
-      returning
-        value(rv_value) type lvc_rndfn .
-    methods get_decimals_o
-      returning
-        value(rv_value) type lvc_decmls .
-    methods get_decmlfield
-      returning
-        value(rv_value) type lvc_dfname .
-    methods get_dd_outlen
-      returning
-        value(rv_value) type lvc_ddlen .
-    methods get_decimals
-      returning
-        value(rv_value) type decimals .
-    methods get_coltext
-      returning
-        value(rv_value) type lvc_txtcol .
-    methods get_scrtext_l
-      returning
-        value(rv_value) type scrtext_l .
-    methods get_scrtext_m
-      returning
-        value(rv_value) type scrtext_m .
-    methods get_scrtext_s
-      returning
-        value(rv_value) type scrtext_s .
-    methods get_colddictxt
-      returning
-        value(rv_value) type lvc_ddict .
-    methods get_selddictxt
-      returning
-        value(rv_value) type lvc_ddict .
-    methods get_tipddictxt
-      returning
-        value(rv_value) type lvc_ddict .
-    methods get_edit
-      returning
-        value(rv_value) type lvc_edit .
-    methods get_tech_col
-      returning
-        value(rv_value) type lvc_tcol .
-    methods get_tech_form
-      returning
-        value(rv_value) type lvc_tform .
-    methods get_tech_comp
-      returning
-        value(rv_value) type lvc_tcomp .
-    methods get_hier_cpos
-      returning
-        value(rv_value) type lvchcolpos .
-    methods get_h_col_key
-      returning
-        value(rv_value) type tv_itmname .
-    methods get_h_select
-      returning
-        value(rv_value) type lvc_select .
-    methods get_dd_roll
-      returning
-        value(rv_value) type rollname .
-    methods get_dragdropid
-      returning
-        value(rv_value) type lvc_ddid .
-    methods get_mac
-      returning
-        value(rv_value) type char01 .
-    methods get_indx_field
-      returning
-        value(rv_value) type int4 .
-    methods get_indx_cfiel
-      returning
-        value(rv_value) type int4 .
-    methods get_indx_qfiel
-      returning
-        value(rv_value) type int4 .
-    methods get_indx_ifiel
-      returning
-        value(rv_value) type int4 .
-    methods get_indx_round
-      returning
-        value(rv_value) type int4 .
-    methods get_indx_decml
-      returning
-        value(rv_value) type int4 .
-    methods get_get_style
-      returning
-        value(rv_value) type char01 .
-    methods get_mark
-      returning
-        value(rv_value) type char01 .
-
+  methods CONSTRUCTOR
+    importing
+      value(IV_FIELDNAME) type LVC_S_FCAT-FIELDNAME
+      !IO_FALV type ref to ZCL_FALV .
+  methods GET_AUTO_VALUE
+    returning
+      value(RV_VALUE) type LVC_AUTO .
+  methods GET_CFIELDNAME
+    returning
+      value(RV_VALUE) type LVC_CFNAME .
+  methods GET_CHECKBOX
+    returning
+      value(RV_VALUE) type LVC_CHECKB .
+  methods GET_CHECKTABLE
+    returning
+      value(RV_VALUE) type TABNAME .
+  methods GET_COLDDICTXT
+    returning
+      value(RV_VALUE) type LVC_DDICT .
+  methods GET_COLOR
+    returning
+      value(RV_VALUE) type LVC_EMPHSZ .
+  methods GET_COLTEXT
+    returning
+      value(RV_VALUE) type LVC_TXTCOL .
+  methods GET_COL_ID
+    returning
+      value(RV_VALUE) type LVC_COLID .
+  methods GET_COL_OPT
+    returning
+      value(RV_VALUE) type LVC_COLOPT .
+  methods GET_COL_POS
+    returning
+      value(RV_VALUE) type LVC_COLPOS .
+  methods GET_CONVEXIT
+    returning
+      value(RV_VALUE) type CONVEXIT .
+  methods GET_CURRENCY
+    returning
+      value(RV_VALUE) type LVC_CURR .
+  methods GET_DATATYPE
+    returning
+      value(RV_VALUE) type DATATYPE_D .
+  methods GET_DD_OUTLEN
+    returning
+      value(RV_VALUE) type LVC_DDLEN .
+  methods GET_DD_ROLL
+    returning
+      value(RV_VALUE) type ROLLNAME .
+  methods GET_DECFLOAT_STYLE
+    returning
+      value(RV_VALUE) type OUTPUTSTYLE .
+  methods GET_DECIMALS
+    returning
+      value(RV_VALUE) type DECIMALS .
+  methods GET_DECIMALS_O
+    returning
+      value(RV_VALUE) type LVC_DECMLS .
+  methods GET_DECMLFIELD
+    returning
+      value(RV_VALUE) type LVC_DFNAME .
+  methods GET_DFIELDNAME
+    returning
+      value(RV_VALUE) type LVCDBGFN .
+  methods GET_DOMNAME
+    returning
+      value(RV_VALUE) type DOMNAME .
+  methods GET_DO_SUM
+    returning
+      value(RV_VALUE) type LVC_DOSUM .
+  methods GET_DRAGDROPID
+    returning
+      value(RV_VALUE) type LVC_DDID .
+  methods GET_DRDN_ALIAS
+    returning
+      value(RV_VALUE) type CHAR01 .
+  methods GET_DRDN_FIELD
+    returning
+      value(RV_VALUE) type LVC_FNAME .
+  methods GET_DRDN_HNDL
+    returning
+      value(RV_VALUE) type INT4 .
+  methods GET_EDIT
+    returning
+      value(RV_VALUE) type LVC_EDIT .
+  methods GET_EDITABLE
+    returning
+      value(RV_EDITABLE) type ABAP_BOOL .
+  methods GET_EDIT_MASK
+    returning
+      value(RV_VALUE) type LVC_EDTMSK .
+  methods GET_EMPHASIZE
+    returning
+      value(RV_VALUE) type LVC_EMPHSZ .
+  methods GET_EXPONENT
+    returning
+      value(RV_VALUE) type LVC_EXPONT .
+  methods GET_F4AVAILABL
+    returning
+      value(RV_VALUE) type DDF4AVAIL .
+  methods GET_FIELDNAME
+    returning
+      value(RV_VALUE) type LVC_FNAME .
+  methods GET_FIX_COLUMN
+    returning
+      value(RV_VALUE) type LVC_FIXCOL .
+  methods GET_GET_STYLE
+    returning
+      value(RV_VALUE) type CHAR01 .
+  methods GET_HIER_CPOS
+    returning
+      value(RV_VALUE) type LVCHCOLPOS .
+  methods GET_HIER_LEVEL
+    returning
+      value(RV_VALUE) type LVC_HIERL .
+  methods GET_HOTSPOT
+    returning
+      value(RV_VALUE) type LVC_HOTSPT .
+  methods GET_HREF_HNDL
+    returning
+      value(RV_VALUE) type INT4 .
+  methods GET_H_COL_KEY
+    returning
+      value(RV_VALUE) type TV_ITMNAME .
+  methods GET_H_FTYPE
+    returning
+      value(RV_VALUE) type LVC_FTYPE .
+  methods GET_H_SELECT
+    returning
+      value(RV_VALUE) type LVC_SELECT .
+  methods GET_ICON
+    returning
+      value(RV_VALUE) type LVC_ICON .
+  methods GET_IFIELDNAME
+    returning
+      value(RV_VALUE) type LVC_FNAME .
+  methods GET_INDX_CFIEL
+    returning
+      value(RV_VALUE) type INT4 .
+  methods GET_INDX_DECML
+    returning
+      value(RV_VALUE) type INT4 .
+  methods GET_INDX_FIELD
+    returning
+      value(RV_VALUE) type INT4 .
+  methods GET_INDX_IFIEL
+    returning
+      value(RV_VALUE) type INT4 .
+  methods GET_INDX_QFIEL
+    returning
+      value(RV_VALUE) type INT4 .
+  methods GET_INDX_ROUND
+    returning
+      value(RV_VALUE) type INT4 .
+  methods GET_INTLEN
+    returning
+      value(RV_VALUE) type INTLEN .
+  methods GET_INTTYPE
+    returning
+      value(RV_VALUE) type INTTYPE .
+  methods GET_JUST
+    returning
+      value(RV_VALUE) type LVC_JUST .
+  methods GET_KEY
+    returning
+      value(RV_VALUE) type LVC_KEY .
+  methods GET_KEY_SEL
+    returning
+      value(RV_VALUE) type LVC_KEYSEL .
+  methods GET_LOWERCASE
+    returning
+      value(RV_VALUE) type LOWERCASE .
+  methods GET_LZERO
+    returning
+      value(RV_VALUE) type LVC_LZERO .
+  methods GET_MAC
+    returning
+      value(RV_VALUE) type CHAR01 .
+  methods GET_MARK
+    returning
+      value(RV_VALUE) type CHAR01 .
+  methods GET_NO_CONVEXT
+    returning
+      value(RV_VALUE) type LVC_NOCONV .
+  methods GET_NO_INIT_CH
+    returning
+      value(RV_VALUE) type CHAR01 .
+  methods GET_NO_MERGING
+    returning
+      value(RV_VALUE) type CHAR01 .
+  methods GET_NO_OUT
+    returning
+      value(RV_VALUE) type LVC_NOOUT .
+  methods GET_NO_SIGN
+    returning
+      value(RV_VALUE) type LVC_NOSIGN .
+  methods GET_NO_SUM
+    returning
+      value(RV_VALUE) type LVC_NOSUM .
+  methods GET_NO_ZERO
+    returning
+      value(RV_VALUE) type LVC_NOZERO .
+  methods GET_OUTPUTLEN
+    returning
+      value(RV_VALUE) type LVC_OUTLEN .
+  methods GET_PARAMETER0
+    returning
+      value(RV_VALUE) type CHAR30 .
+  methods GET_PARAMETER1
+    returning
+      value(RV_VALUE) type CHAR30 .
+  methods GET_PARAMETER2
+    returning
+      value(RV_VALUE) type CHAR30 .
+  methods GET_PARAMETER3
+    returning
+      value(RV_VALUE) type CHAR30 .
+  methods GET_PARAMETER4
+    returning
+      value(RV_VALUE) type CHAR30 .
+  methods GET_PARAMETER5
+    returning
+      value(RV_VALUE) type INT4 .
+  methods GET_PARAMETER6
+    returning
+      value(RV_VALUE) type INT4 .
+  methods GET_PARAMETER7
+    returning
+      value(RV_VALUE) type INT4 .
+  methods GET_PARAMETER8
+    returning
+      value(RV_VALUE) type INT4 .
+  methods GET_PARAMETER9
+    returning
+      value(RV_VALUE) type INT4 .
+  methods GET_QFIELDNAME
+    returning
+      value(RV_VALUE) type LVC_QFNAME .
+  methods GET_QUANTITY
+    returning
+      value(RV_VALUE) type LVC_QUAN .
+  methods GET_READONLY
+    returning
+      value(RV_READ_ONLY) type ABAP_BOOL .
+  methods GET_REF_FIELD
+    returning
+      value(RV_VALUE) type LVC_RFNAME .
+  methods GET_REF_TABLE
+    returning
+      value(RV_VALUE) type LVC_RTNAME .
+  methods GET_REPREP
+    returning
+      value(RV_VALUE) type LVC_CRPRP .
+  methods GET_REPTEXT
+    returning
+      value(RV_VALUE) type REPTEXT .
+  methods GET_ROLLNAME
+    returning
+      value(RV_VALUE) type LVC_ROLL .
+  methods GET_ROUND
+    returning
+      value(RV_VALUE) type LVC_ROUND .
+  methods GET_ROUNDFIELD
+    returning
+      value(RV_VALUE) type LVC_RNDFN .
+  methods GET_ROW_POS
+    returning
+      value(RV_VALUE) type LVC_ROWPOS .
+  methods GET_SCRTEXT_L
+    returning
+      value(RV_VALUE) type SCRTEXT_L .
+  methods GET_SCRTEXT_M
+    returning
+      value(RV_VALUE) type SCRTEXT_M .
+  methods GET_SCRTEXT_S
+    returning
+      value(RV_VALUE) type SCRTEXT_S .
+  methods GET_SELDDICTXT
+    returning
+      value(RV_VALUE) type LVC_DDICT .
+  methods GET_SELTEXT
+    returning
+      value(RV_VALUE) type LVC_TXT .
+  methods GET_SP_GROUP
+    returning
+      value(RV_VALUE) type LVC_SPGRP .
+  methods GET_STYLE
+    returning
+      value(RV_VALUE) type LVC_STYLE .
+  methods GET_STYLE2
+    returning
+      value(RV_VALUE) type LVC_STYLE .
+  methods GET_STYLE3
+    returning
+      value(RV_VALUE) type LVC_STYLE .
+  methods GET_STYLE4
+    returning
+      value(RV_VALUE) type LVC_STYLE .
+  methods GET_SYMBOL
+    returning
+      value(RV_VALUE) type LVC_SYMBOL .
+  methods GET_TABNAME
+    returning
+      value(RV_VALUE) type LVC_TNAME .
+  methods GET_TECH
+    returning
+      value(RV_VALUE) type LVC_TECH .
+  methods GET_TECH_COL
+    returning
+      value(RV_VALUE) type LVC_TCOL .
+  methods GET_TECH_COMP
+    returning
+      value(RV_VALUE) type LVC_TCOMP .
+  methods GET_TECH_FORM
+    returning
+      value(RV_VALUE) type LVC_TFORM .
+  methods GET_TIPDDICTXT
+    returning
+      value(RV_VALUE) type LVC_DDICT .
+  methods GET_TOOLTIP
+    returning
+      value(RV_VALUE) type LVC_TIP .
+  methods GET_TXT_FIELD
+    returning
+      value(RV_VALUE) type LVC_FNAME .
+  methods GET_VALEXI
+    returning
+      value(RV_VALUE) type VALEXI .
+  methods GET_WEB_FIELD
+    returning
+      value(RV_VALUE) type LVC_FNAME .
+  methods SET_AUTO_VALUE
+    importing
+      value(IV_VALUE) type LVC_AUTO
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_CFIELDNAME
+    importing
+      value(IV_VALUE) type LVC_CFNAME
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_CHECKBOX
+    importing
+      value(IV_VALUE) type LVC_CHECKB
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_CHECKTABLE
+    importing
+      value(IV_VALUE) type TABNAME
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_COLDDICTXT
+    importing
+      value(IV_VALUE) type LVC_DDICT
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_COLOR
+    importing
+      value(IV_VALUE) type LVC_EMPHSZ
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_COLTEXT
+    importing
+      value(IV_VALUE) type LVC_TXTCOL
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_COL_ID
+    importing
+      value(IV_VALUE) type LVC_COLID
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_COL_OPT
+    importing
+      value(IV_VALUE) type LVC_COLOPT
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_COL_POS
+    importing
+      value(IV_VALUE) type LVC_COLPOS
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_CONVEXIT
+    importing
+      value(IV_VALUE) type CONVEXIT
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_CURRENCY
+    importing
+      value(IV_VALUE) type LVC_CURR
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_DATATYPE
+    importing
+      value(IV_VALUE) type DATATYPE_D
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_DD_OUTLEN
+    importing
+      value(IV_VALUE) type LVC_DDLEN
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_DD_ROLL
+    importing
+      value(IV_VALUE) type ROLLNAME
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_DECFLOAT_STYLE
+    importing
+      value(IV_VALUE) type OUTPUTSTYLE
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_DECIMALS
+    importing
+      value(IV_VALUE) type DECIMALS
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_DECIMALS_O
+    importing
+      value(IV_VALUE) type LVC_DECMLS
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_DECMLFIELD
+    importing
+      value(IV_VALUE) type LVC_DFNAME
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_DFIELDNAME
+    importing
+      value(IV_VALUE) type LVCDBGFN
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_DOMNAME
+    importing
+      value(IV_VALUE) type DOMNAME
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_DO_SUM
+    importing
+      value(IV_VALUE) type LVC_DOSUM
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_DRAGDROPID
+    importing
+      value(IV_VALUE) type LVC_DDID
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_DRDN_ALIAS
+    importing
+      value(IV_VALUE) type CHAR01
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_DRDN_FIELD
+    importing
+      value(IV_VALUE) type LVC_FNAME
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_DRDN_HNDL
+    importing
+      value(IV_VALUE) type INT4
+      value(IV_USE_DOMAIN_VALUES) type ABAP_BOOL default 'X'
+      value(IV_USE_ALIAS) type ABAP_BOOL default 'X'
+      value(IT_DROP_DOWN) type LVC_T_DROP optional
+      value(IT_DROP_DOWN_ALIAS) type LVC_T_DRAL optional
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_EDIT
+    importing
+      value(IV_VALUE) type LVC_EDIT
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_EDITABLE
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_EDIT_MASK
+    importing
+      value(IV_VALUE) type LVC_EDTMSK
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_EMPHASIZE
+    importing
+      value(IV_VALUE) type LVC_EMPHSZ
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_EXPONENT
+    importing
+      value(IV_VALUE) type LVC_EXPONT
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_F4AVAILABL
+    importing
+      value(IV_VALUE) type DDF4AVAIL
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_FIELDNAME
+    importing
+      value(IV_VALUE) type LVC_FNAME
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_FIX_COLUMN
+    importing
+      value(IV_VALUE) type LVC_FIXCOL
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_GET_STYLE
+    importing
+      value(IV_VALUE) type CHAR01
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_HIER_CPOS
+    importing
+      value(IV_VALUE) type LVCHCOLPOS
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_HIER_LEVEL
+    importing
+      value(IV_VALUE) type LVC_HIERL
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_HOTSPOT
+    importing
+      value(IV_VALUE) type LVC_HOTSPT
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_HREF_HNDL
+    importing
+      value(IV_VALUE) type INT4
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_H_COL_KEY
+    importing
+      value(IV_VALUE) type TV_ITMNAME
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_H_FTYPE
+    importing
+      value(IV_VALUE) type LVC_FTYPE
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_H_SELECT
+    importing
+      value(IV_VALUE) type LVC_SELECT
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_ICON
+    importing
+      value(IV_VALUE) type LVC_ICON
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_IFIELDNAME
+    importing
+      value(IV_VALUE) type LVC_FNAME
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_INDX_CFIEL
+    importing
+      value(IV_VALUE) type INT4
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_INDX_DECML
+    importing
+      value(IV_VALUE) type INT4
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_INDX_FIELD
+    importing
+      value(IV_VALUE) type INT4
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_INDX_IFIEL
+    importing
+      value(IV_VALUE) type INT4
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_INDX_QFIEL
+    importing
+      value(IV_VALUE) type INT4
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_INDX_ROUND
+    importing
+      value(IV_VALUE) type INT4
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_INTLEN
+    importing
+      value(IV_VALUE) type INTLEN
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_INTTYPE
+    importing
+      value(IV_VALUE) type INTTYPE
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_JUST
+    importing
+      value(IV_VALUE) type LVC_JUST
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_KEY
+    importing
+      value(IV_VALUE) type LVC_KEY
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_KEY_SEL
+    importing
+      value(IV_VALUE) type LVC_KEYSEL
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_LOWERCASE
+    importing
+      value(IV_VALUE) type LOWERCASE
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_LZERO
+    importing
+      value(IV_VALUE) type LVC_LZERO
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_MAC
+    importing
+      value(IV_VALUE) type CHAR01
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_MARK
+    importing
+      value(IV_VALUE) type CHAR01
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_NO_CONVEXT
+    importing
+      value(IV_VALUE) type LVC_NOCONV
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_NO_INIT_CH
+    importing
+      value(IV_VALUE) type CHAR01
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_NO_MERGING
+    importing
+      value(IV_VALUE) type CHAR01
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_NO_OUT
+    importing
+      value(IV_VALUE) type LVC_NOOUT
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_NO_SIGN
+    importing
+      value(IV_VALUE) type LVC_NOSIGN
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_NO_SUM
+    importing
+      value(IV_VALUE) type LVC_NOSUM
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_NO_ZERO
+    importing
+      value(IV_VALUE) type LVC_NOZERO
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_OUTPUTLEN
+    importing
+      value(IV_VALUE) type LVC_OUTLEN
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_PARAMETER0
+    importing
+      value(IV_VALUE) type CHAR30
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_PARAMETER1
+    importing
+      value(IV_VALUE) type CHAR30
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_PARAMETER2
+    importing
+      value(IV_VALUE) type CHAR30
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_PARAMETER3
+    importing
+      value(IV_VALUE) type CHAR30
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_PARAMETER4
+    importing
+      value(IV_VALUE) type CHAR30
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_PARAMETER5
+    importing
+      value(IV_VALUE) type INT4
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_PARAMETER6
+    importing
+      value(IV_VALUE) type INT4
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_PARAMETER7
+    importing
+      value(IV_VALUE) type INT4
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_PARAMETER8
+    importing
+      value(IV_VALUE) type INT4
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_PARAMETER9
+    importing
+      value(IV_VALUE) type INT4
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_QFIELDNAME
+    importing
+      value(IV_VALUE) type LVC_QFNAME
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_QUANTITY
+    importing
+      value(IV_VALUE) type LVC_QUAN
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_READONLY
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_REF_FIELD
+    importing
+      value(IV_VALUE) type LVC_RFNAME
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_REF_TABLE
+    importing
+      value(IV_VALUE) type LVC_RTNAME
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_REPREP
+    importing
+      value(IV_VALUE) type LVC_CRPRP
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_REPTEXT
+    importing
+      value(IV_VALUE) type REPTEXT
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_ROLLNAME
+    importing
+      value(IV_VALUE) type LVC_ROLL
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_ROUND
+    importing
+      value(IV_VALUE) type LVC_ROUND
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_ROUNDFIELD
+    importing
+      value(IV_VALUE) type LVC_RNDFN
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_ROW_POS
+    importing
+      value(IV_VALUE) type LVC_ROWPOS
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_SCRTEXT_L
+    importing
+      value(IV_VALUE) type SCRTEXT_L
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_SCRTEXT_M
+    importing
+      value(IV_VALUE) type SCRTEXT_M
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_SCRTEXT_S
+    importing
+      value(IV_VALUE) type SCRTEXT_S
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_SELDDICTXT
+    importing
+      value(IV_VALUE) type LVC_DDICT
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_SELTEXT
+    importing
+      value(IV_VALUE) type LVC_TXT
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_SP_GROUP
+    importing
+      value(IV_VALUE) type LVC_SPGRP
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_STYLE
+    importing
+      value(IV_VALUE) type LVC_STYLE
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_STYLE2
+    importing
+      value(IV_VALUE) type LVC_STYLE
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_STYLE3
+    importing
+      value(IV_VALUE) type LVC_STYLE
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_STYLE4
+    importing
+      value(IV_VALUE) type LVC_STYLE
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_SYMBOL
+    importing
+      value(IV_VALUE) type LVC_SYMBOL
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_TABNAME
+    importing
+      value(IV_VALUE) type LVC_TNAME
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_TECH
+    importing
+      value(IV_VALUE) type LVC_TECH
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_TECH_COL
+    importing
+      value(IV_VALUE) type LVC_TCOL
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_TECH_COMP
+    importing
+      value(IV_VALUE) type LVC_TCOMP
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_TECH_FORM
+    importing
+      value(IV_VALUE) type LVC_TFORM
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_TEXTS
+    importing
+      value(IV_TEXT_S) type SCRTEXT_S
+      value(IV_TEXT_M) type SCRTEXT_M optional
+      value(IV_TEXT_L) type SCRTEXT_L optional
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_TIPDDICTXT
+    importing
+      value(IV_VALUE) type LVC_DDICT
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_TOOLTIP
+    importing
+      value(IV_VALUE) type LVC_TIP
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_TXT_FIELD
+    importing
+      value(IV_VALUE) type LVC_FNAME
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_VALEXI
+    importing
+      value(IV_VALUE) type VALEXI
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
+  methods SET_WEB_FIELD
+    importing
+      value(IV_VALUE) type LVC_FNAME
+    returning
+      value(R_COLUMN) type ref to ZCL_FALV_COLUMN .
   protected section.
-  private section.
+private section.
 
-    data falv type ref to zcl_falv .
+  data FALV type ref to ZCL_FALV .
 
-    methods change_setting
-      importing
-        value(iv_value)   type any
-        value(iv_setting) type string .
-
-    methods get_setting
-      importing
-        value(iv_setting) type string
-      exporting
-        value(e_value)    type any.
+  methods CHANGE_SETTING
+    importing
+      value(IV_VALUE) type ANY
+      value(IV_SETTING) type STRING .
+  methods GET_SETTING
+    importing
+      value(IV_SETTING) type STRING
+    exporting
+      value(E_VALUE) type ANY .
 ENDCLASS.
 
 
@@ -980,10 +1094,124 @@ CLASS ZCL_FALV_COLUMN IMPLEMENTATION.
   endmethod.
 
 
-  method set_drdn_hndl.
-    change_setting( iv_value = iv_value iv_setting = 'DRDN_HNDL' ).
+  METHOD set_drdn_hndl.
+
+    DATA:
+           lt_drop_down        TYPE  lvc_t_drop
+          ,ls_drop_down        LIKE LINE OF lt_drop_down
+          ,lt_drop_down_alias  TYPE	lvc_t_dral
+          ,ls_drop_down_alias  LIKE LINE OF lt_drop_down_alias
+          ,lo_typedescr        TYPE REF TO cl_abap_typedescr
+          ,lo_elemdescr        TYPE REF TO cl_abap_elemdescr
+          ,lv_domname          TYPE domname
+          ,lt_fixed_values     TYPE cl_abap_elemdescr=>fixvalues
+          ,ls_fixed_value      LIKE LINE OF lt_fixed_values
+          .
+
+
+    IF ( ( it_drop_down       IS NOT INITIAL ) OR
+         ( it_drop_down_alias IS NOT INITIAL ) ).
+
+      APPEND LINES OF it_drop_down       TO lt_drop_down.
+      APPEND LINES OF it_drop_down_alias TO lt_drop_down_alias.
+
+    ELSE.
+      IF ( iv_use_domain_values EQ abap_true ).
+        lv_domname = me->get_domname( ).
+
+        CALL METHOD cl_abap_elemdescr=>describe_by_name
+          EXPORTING
+            p_name         = lv_domname
+          RECEIVING
+            p_descr_ref    = lo_typedescr
+          EXCEPTIONS
+            type_not_found = 1
+            OTHERS         = 2.
+        IF sy-subrc EQ 0.
+          lo_elemdescr ?= lo_typedescr.
+
+*        get_ddic_fixed_values
+          CALL METHOD lo_elemdescr->get_ddic_fixed_values
+*  EXPORTING
+*    p_langu        = SY-LANGU
+            RECEIVING
+              p_fixed_values = lt_fixed_values
+*  EXCEPTIONS
+*             not_found      = 1
+*             no_ddic_type   = 2
+*             others         = 3
+            .
+          IF sy-subrc EQ 0.
+
+            LOOP AT lt_fixed_values INTO ls_fixed_value.
+
+
+              IF ( iv_use_alias EQ abap_true ).
+                CLEAR: ls_drop_down_alias.
+
+                ls_drop_down_alias-handle = iv_value.
+*              ls_drop_down_alias-value = ls_fixed_value-ddtext.
+                CONCATENATE ls_fixed_value-ddtext '['
+                  INTO ls_drop_down_alias-value SEPARATED BY space.
+
+                CONCATENATE ls_drop_down_alias-value
+                             ls_fixed_value-low ']'
+                  INTO ls_drop_down_alias-value.
+
+                ls_drop_down_alias-int_value = ls_fixed_value-low.
+
+                APPEND ls_drop_down_alias TO lt_drop_down_alias.
+              ELSE.
+                CLEAR: ls_drop_down.
+
+                ls_drop_down-handle = iv_value.
+                ls_drop_down-value = ls_fixed_value-low.
+
+                APPEND ls_drop_down TO lt_drop_down.
+              ENDIF.
+
+            ENDLOOP.
+
+
+
+          ELSE.
+* Implement suitable error handling here
+          ENDIF.
+
+        ENDIF.
+      ELSE.
+*                Implement suitable error handling here
+      ENDIF.
+
+    ENDIF.
+
+
+
+
+    IF ( ( lt_drop_down       IS NOT INITIAL ) OR
+         ( lt_drop_down_alias IS NOT INITIAL ) ).
+
+
+      change_setting( iv_value = iv_value iv_setting = 'DRDN_HNDL' ).
+
+      IF ( iv_use_alias EQ abap_true ).
+        falv->set_drop_down_table(
+          it_drop_down_alias = lt_drop_down_alias ).
+*      me->set_drdn_alias( 'X' ).
+        change_setting( iv_value = 'X' iv_setting = 'DRDN_ALIAS' ).
+      ELSE.
+        falv->set_drop_down_table(
+          it_drop_down       = lt_drop_down
+           ).
+      ENDIF.
+
+
+    ENDIF.
+
+
     r_column = me.
-  endmethod.
+
+  ENDMETHOD.
 
 
   method set_edit.


### PR DESCRIPTION
Hi Łukasz,
   I figure out one bug on vertical merge.... this method CLEAR the value of next column....
![image](https://github.com/fidley/falv/assets/59447432/3a0c3c97-520e-4989-aae1-bf11f79377f0)

I resolved removing the line "CLEAR <data>-value." [32] into the method "SET_MERGE_VERTICALLY"

And this work for me:
![image](https://github.com/fidley/falv/assets/59447432/50dd37ae-a335-485c-ada7-e462df43cce8)


and last I did some chenges on the method "SET_DRDN_HNDL" of the class ZCL_FALV_COLUMN..
I added this 4 optional parameters:
![image](https://github.com/fidley/falv/assets/59447432/48cdcbe5-d71a-4bfa-bd5a-d2b8375594e2)

in this way will appear automatically the dropdown values retrived from related domain of the column, if exist.



